### PR TITLE
v0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "binfiddle"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "binfiddle"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "binfiddle"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -117,6 +117,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shell-words",
  "tempfile",
  "termcolor",
  "thiserror",
@@ -683,6 +684,12 @@ dependencies = [
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "binfiddle"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,16 +113,19 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "binfiddle"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "atty",
+ "blake3",
  "byteorder",
  "clap",
+ "crc32fast",
  "criterion",
  "encoding_rs",
  "hex",
  "libc",
+ "md5",
  "memchr",
  "memmap2",
  "nix",
@@ -119,6 +134,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "shell-words",
  "tempfile",
  "termcolor",
@@ -130,6 +146,29 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -245,6 +284,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +383,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +444,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -455,6 +557,12 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -706,6 +814,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +906,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +928,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "binfiddle"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -131,6 +131,7 @@ dependencies = [
  "criterion",
  "encoding_rs",
  "hex",
+ "indicatif",
  "libc",
  "md5",
  "memchr",
@@ -293,6 +294,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +432,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +545,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +643,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +697,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "proc-macro2"
@@ -938,6 +983,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,6 +1075,16 @@ name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "binfiddle"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "binfiddle"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "binfiddle"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -113,6 +113,7 @@ dependencies = [
  "libc",
  "memchr",
  "memmap2",
+ "nix",
  "rayon",
  "regex",
  "serde",
@@ -163,6 +164,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "ciborium"
@@ -461,6 +468,18 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "binfiddle"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "binfiddle"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -110,6 +110,7 @@ dependencies = [
  "criterion",
  "encoding_rs",
  "hex",
+ "libc",
  "memchr",
  "memmap2",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "binfiddle"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,11 +112,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "binfiddle"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "atty",
+ "base64",
  "blake3",
  "byteorder",
  "clap",
@@ -134,11 +141,13 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha1",
  "sha2",
  "shell-words",
  "tempfile",
  "termcolor",
  "thiserror",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -814,6 +823,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1138,12 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "binfiddle"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "binfiddle"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "binfiddle"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binfiddle"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 authors = ["Araray Velho <araray@gmail.com"]
 description = "Binfiddle is a developer-focused binary manipulation toolkit designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, and custom exploration of binary data across a variety of formats. Whether you're reverse-engineering, debugging, or building custom workflows for binary files, Binfiddle provides the essential tools without the bloat."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binfiddle"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 authors = ["Araray Velho <araray@gmail.com"]
 description = "Binfiddle is a developer-focused binary manipulation toolkit designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, and custom exploration of binary data across a variety of formats. Whether you're reverse-engineering, debugging, or building custom workflows for binary files, Binfiddle provides the essential tools without the bloat."
@@ -19,9 +19,12 @@ byteorder = "1.5.0"
 encoding_rs = "0.8"
 memmap2 = "0.9.9"
 md5 = "0.7"
+sha1 = "0.10"
 sha2 = "0.10"
 blake3 = { version = "1.5", features = ["pure"] }
 crc32fast = "1.3"
+xxhash-rust = { version = "0.8", features = ["xxh64"] }
+base64 = "0.22"
 regex = "1.12.2"
 memchr = "2.7"
 termcolor = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binfiddle"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 authors = ["Araray Velho <araray@gmail.com"]
 description = "Binfiddle is a developer-focused binary manipulation toolkit designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, and custom exploration of binary data across a variety of formats. Whether you're reverse-engineering, debugging, or building custom workflows for binary files, Binfiddle provides the essential tools without the bloat."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binfiddle"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 authors = ["Araray Velho <araray@gmail.com"]
 description = "Binfiddle is a developer-focused binary manipulation toolkit designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, and custom exploration of binary data across a variety of formats. Whether you're reverse-engineering, debugging, or building custom workflows for binary files, Binfiddle provides the essential tools without the bloat."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binfiddle"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 authors = ["Araray Velho <araray@gmail.com"]
 description = "Binfiddle is a developer-focused binary manipulation toolkit designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, and custom exploration of binary data across a variety of formats. Whether you're reverse-engineering, debugging, or building custom workflows for binary files, Binfiddle provides the essential tools without the bloat."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binfiddle"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 authors = ["Araray Velho <araray@gmail.com"]
 description = "Binfiddle is a developer-focused binary manipulation toolkit designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, and custom exploration of binary data across a variety of formats. Whether you're reverse-engineering, debugging, or building custom workflows for binary files, Binfiddle provides the essential tools without the bloat."
@@ -29,6 +29,7 @@ serde_json = "1.0"
 shell-words = "1.1"
 tempfile = "3.24"
 libc = "0.2"
+nix = { version = "0.29", features = ["process", "ptrace"] }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binfiddle"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 authors = ["Araray Velho <araray@gmail.com"]
 description = "Binfiddle is a developer-focused binary manipulation toolkit designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, and custom exploration of binary data across a variety of formats. Whether you're reverse-engineering, debugging, or building custom workflows for binary files, Binfiddle provides the essential tools without the bloat."
@@ -18,6 +18,10 @@ hex = "0.4"
 byteorder = "1.5.0"
 encoding_rs = "0.8"
 memmap2 = "0.9.9"
+md5 = "0.7"
+sha2 = "0.10"
+blake3 = { version = "1.5", features = ["pure"] }
+crc32fast = "1.3"
 regex = "1.12.2"
 memchr = "2.7"
 termcolor = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binfiddle"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 authors = ["Araray Velho <araray@gmail.com"]
 description = "Binfiddle is a developer-focused binary manipulation toolkit designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, and custom exploration of binary data across a variety of formats. Whether you're reverse-engineering, debugging, or building custom workflows for binary files, Binfiddle provides the essential tools without the bloat."
@@ -26,9 +26,10 @@ rayon = "1.11.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
+shell-words = "1.1"
+tempfile = "3.24"
 
 [dev-dependencies]
-tempfile = "3.24"
 criterion = { version = "0.8", features = ["html_reports"] }
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binfiddle"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Araray Velho <araray@gmail.com"]
 description = "Binfiddle is a developer-focused binary manipulation toolkit designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, and custom exploration of binary data across a variety of formats. Whether you're reverse-engineering, debugging, or building custom workflows for binary files, Binfiddle provides the essential tools without the bloat."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binfiddle"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 authors = ["Araray Velho <araray@gmail.com"]
 description = "Binfiddle is a developer-focused binary manipulation toolkit designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, and custom exploration of binary data across a variety of formats. Whether you're reverse-engineering, debugging, or building custom workflows for binary files, Binfiddle provides the essential tools without the bloat."
@@ -28,6 +28,7 @@ serde_yaml = "0.9"
 serde_json = "1.0"
 shell-words = "1.1"
 tempfile = "3.24"
+libc = "0.2"
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binfiddle"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 authors = ["Araray Velho <araray@gmail.com"]
 description = "Binfiddle is a developer-focused binary manipulation toolkit designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, and custom exploration of binary data across a variety of formats. Whether you're reverse-engineering, debugging, or building custom workflows for binary files, Binfiddle provides the essential tools without the bloat."
@@ -15,6 +15,7 @@ clap = { version = "4.5.55", features = ["derive"] }
 anyhow = "1.0"
 thiserror = "2.0.18"
 hex = "0.4"
+indicatif = "0.17"
 byteorder = "1.5.0"
 encoding_rs = "0.8"
 memmap2 = "0.9.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binfiddle"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 authors = ["Araray Velho <araray@gmail.com"]
 description = "Binfiddle is a developer-focused binary manipulation toolkit designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, and custom exploration of binary data across a variety of formats. Whether you're reverse-engineering, debugging, or building custom workflows for binary files, Binfiddle provides the essential tools without the bloat."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binfiddle"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 authors = ["Araray Velho <araray@gmail.com"]
 description = "Binfiddle is a developer-focused binary manipulation toolkit designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, and custom exploration of binary data across a variety of formats. Whether you're reverse-engineering, debugging, or building custom workflows for binary files, Binfiddle provides the essential tools without the bloat."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "binfiddle"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Araray Velho <araray@gmail.com"]
 description = "Binfiddle is a developer-focused binary manipulation toolkit designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, and custom exploration of binary data across a variety of formats. Whether you're reverse-engineering, debugging, or building custom workflows for binary files, Binfiddle provides the essential tools without the bloat."
 license = "BSD 3-Clause Clear License"
-license-file = "https://github.com/araray/binfiddle/LICENSE"
 repository = "https://github.com/araray/binfiddle"
 keywords = ["binary", "hex", "patching", "forensics", "reverse-engineering"]
 categories = ["command-line-utilities", "development-tools"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binfiddle"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 authors = ["Araray Velho <araray@gmail.com"]
 description = "Binfiddle is a developer-focused binary manipulation toolkit designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, and custom exploration of binary data across a variety of formats. Whether you're reverse-engineering, debugging, or building custom workflows for binary files, Binfiddle provides the essential tools without the bloat."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binfiddle"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 authors = ["Araray Velho <araray@gmail.com"]
 description = "Binfiddle is a developer-focused binary manipulation toolkit designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, and custom exploration of binary data across a variety of formats. Whether you're reverse-engineering, debugging, or building custom workflows for binary files, Binfiddle provides the essential tools without the bloat."

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
 
-*Version 0.11.0 | Cross-platform (Windows/Linux/macOS) | x86_64/Arm64 Support*
+*Version 0.12.0 | Cross-platform (Windows/Linux/macOS) | x86_64/Arm64 Support*
 
 Binfiddle is a **developer-focused binary manipulation toolkit** designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, statistical analysis, and custom exploration of binary data across a variety of formats.
 
@@ -384,19 +384,19 @@ Parse and interpret binary data according to YAML structure templates, useful fo
 
 ```bash
 # Parse an ELF file header
-binfiddle -i /bin/ls struct elf_header.yaml
+binfiddle struct elf_header.yaml < /bin/ls
 
 # List fields in a template without parsing data
 binfiddle struct my_format.yaml --list-fields
 
 # Get a specific field value
-binfiddle -i firmware.bin struct header.yaml --get version
+binfiddle struct header.yaml --get version < firmware.bin
 
 # Output as JSON
-binfiddle -i data.bin struct format.yaml --output-format json
+binfiddle struct format.yaml --output-format json < data.bin
 
 # Output as YAML
-binfiddle -i data.bin struct format.yaml --output-format yaml
+binfiddle struct format.yaml --output-format yaml < data.bin
 ```
 
 **Template Format (YAML):**
@@ -430,6 +430,23 @@ fields:
 | `hex_string` | Variable | Raw bytes as hex |
 | `string` | Variable | ASCII/UTF-8 string |
 | `bytes` | Variable | Raw byte array |
+| `computed` | — | Virtual field from an expression |
+
+**Dynamic Templates:**
+
+Templates support field references (`$fieldname`), magic variables (`$@prev_end`, `$@file_size`), conditional fields (`when:`), computed fields, bitfields, and counted arrays.
+
+```yaml
+fields:
+  - name: filename_length
+    offset: 0x1A
+    size: 2
+    type: u16
+  - name: filename
+    offset: 0x1E
+    size: $filename_length
+    type: string
+```
 
 **Struct Options:**
 
@@ -564,7 +581,10 @@ src/
 │   ├── edit.rs      # Edit command (insert/remove/replace)
 │   ├── search.rs    # Search command (exact/regex/mask/parallel)
 │   ├── analyze.rs   # Analyze command (entropy/histogram/IC)
-│   └── diff.rs      # Diff command (simple/unified/side-by-side/patch)
+│   ├── diff.rs      # Diff command (simple/unified/side-by-side/patch)
+│   ├── convert.rs   # Convert command (encoding/line endings/BOM)
+│   ├── patch.rs     # Patch command (apply/revert binary patches)
+│   └── struct_cmd.rs # Struct command (template-based parsing)
 └── utils/
     ├── mod.rs       # Utility exports
     ├── parsing.rs   # Range and format parsing
@@ -584,6 +604,7 @@ pub enum BinarySource {
     File(PathBuf),       // Read from file
     Stdin,               // Read from stdin
     RawData(Vec<u8>),    // In-memory data
+    MemoryAddress(usize), // Process memory (reserved)
 }
 ```
 
@@ -591,10 +612,11 @@ pub enum BinarySource {
 
 All operations return `Result<T, BinfiddleError>` with specific error types:
 - `Io` — File not found, permission denied, etc.
-- `Parse` — Invalid hex, decimal, or format strings
+- `Parse` — Invalid hex, decimal, template YAML, or format strings
 - `InvalidRange` — Out of bounds or invalid range specification
 - `InvalidChunkSize` — Chunk size is 0 or exceeds data
 - `InvalidInput` — Unknown format or invalid input
+- `UnsupportedOperation` — Feature not yet implemented (e.g., memory address access)
 
 ## Contributing
 
@@ -613,33 +635,28 @@ cargo test -- --nocapture
 cargo build --release
 
 # Build for all platforms
-./build_releases.sh
+./scripts/build_releases.sh --native
 ```
 
 ### Code Style
 
 - Follow Rust standard formatting (`cargo fmt`)
-- Run clippy for lints (`cargo clippy`)
+- Run clippy with zero warnings (`cargo clippy -- -D warnings`)
 - Add tests for new functionality
 - Document public APIs with doc comments
 
 ## Roadmap
 
-TBD
-
-### Completed Features
-
-- ✅ **Read/Write/Edit** — Core binary manipulation
-- ✅ **Search** — Exact, regex, and wildcard pattern matching with parallel processing
-- ✅ **Analyze** — Entropy, histogram, and Index of Coincidence analysis
-- ✅ **Diff** — Binary comparison with multiple output formats
-
-### Planned Features
-
-- **Patch** — Apply binary patches from diff output
-- **Convert** — Encoding and line ending conversion
-- **Struct** — Structure-aware parsing with templates
-- **Memory** — Live process memory inspection
+| Phase | Theme | Status |
+|-------|-------|--------|
+| 1 | Core read/write/edit | ✅ Complete |
+| 2 | Search, analyze, diff | ✅ Complete |
+| 3 | Convert, patch, struct | ✅ Complete |
+| 4 | Template system evolution | 🔄 In progress |
+| 5 | Bit-level precision | 🔲 Planned |
+| 6 | Command chaining & pipelines | 🔲 Planned |
+| 7 | Live process memory | 🔲 Planned |
+| 8 | Advanced analysis & intelligence | 🔲 Planned |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
 
-*Version 0.17.0 | Cross-platform (Windows/Linux/macOS) | x86_64/Arm64 Support*
+*Version 0.18.0 | Cross-platform (Windows/Linux/macOS) | x86_64/Arm64 Support*
 
 Binfiddle is a **developer-focused binary manipulation toolkit** designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, statistical analysis, and custom exploration of binary data across a variety of formats.
 
@@ -436,6 +436,14 @@ binfiddle --process-self --address 0x7ffd12345678 --size 4 \
 # Overwrite bytes in another process's writable memory
 binfiddle --pid 1234 --address 0x7f8a1b2c3000 --size 4 \
     --allow-write write 0 CAFEBABE
+
+# Force-write a read-only region in the current process (dangerous)
+binfiddle --process-self --address 0x7ffd12345678 --size 4 \
+    --allow-write --force-writable write 0 DEADBEEF
+
+# Force-write a read-only region in another process (Linux x86_64, dangerous)
+binfiddle --pid 1234 --address 0x7f8a1b2c3000 --size 4 \
+    --allow-write --force-writable write 0 CAFEBABE
 ```
 
 **Process Memory Options:**
@@ -448,8 +456,9 @@ binfiddle --pid 1234 --address 0x7f8a1b2c3000 --size 4 \
 | `--address` | Base address to read from or write to (hex or decimal). |
 | `--size` | Number of bytes to read or write (hex or decimal). |
 | `--allow-write` | Opt-in required for any process-memory write. |
+| `--force-writable` | Temporarily make read-only pages writable before writing. |
 
-> **Note:** Cross-process writes require the target region to be writable. Writes to read-only regions are rejected unless a future `--force-writable` option is added.
+> **Note:** `--force-writable` uses `mprotect` for the current process and ptrace syscall injection for cross-process writes (Linux x86_64 only). It is inherently risky and should be used with care.
 
 #### `struct <TEMPLATE>` — Parse binary data using structure templates
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
 
-*Version 0.13.0 | Cross-platform (Windows/Linux/macOS) | x86_64/Arm64 Support*
+*Version 0.14.0 | Cross-platform (Windows/Linux/macOS) | x86_64/Arm64 Support*
 
 Binfiddle is a **developer-focused binary manipulation toolkit** designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, statistical analysis, and custom exploration of binary data across a variety of formats.
 
@@ -38,6 +38,7 @@ Whether you're reverse-engineering firmware, debugging binary protocols, analyzi
 | **Diff** | Compare binary files with multiple output formats |
 | **Patch** | Apply binary patches (works with diff --format patch output) |
 | **Convert** | Text encoding conversion and line ending normalization |
+| **Chain** | Pipe multiple binfiddle commands together without shell escaping |
 | **Struct** | Parse binary data using YAML templates for structure definitions |
 
 ### Key Differentiators
@@ -378,6 +379,35 @@ diff modified.bin reconstructed.bin && echo "Perfect match!"
 0x00000002:be:ca
 ```
 
+#### `chain --step <COMMAND>` — Execute multiple commands in sequence
+
+Run several binfiddle commands in order, passing the byte output of each step as the input to the next. This avoids shell pipe escaping and makes multi-step transformations explicit.
+
+Intermediate steps must produce byte output (e.g., `write`, `edit`, `replace`, `convert`). The final step may produce text output.
+
+```bash
+# Replace a header and then patch a byte
+binfiddle -i firmware.bin -o patched.bin chain \
+    --step "edit replace 0..4 44415431" \
+    --step "write 8 00"
+
+# Chain from stdin and read the result
+printf '\x00\x11\x22\x33' | binfiddle chain \
+    --step "edit replace 0..2 4142" \
+    --step "read 0..4"
+
+# Run silently so intermediate diagnostics do not pollute stderr
+binfiddle --silent -i data.bin -o out.bin chain \
+    --step "edit replace 0..8 1234567890abcdef" \
+    --step "write 0 ff"
+```
+
+**Chain Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--step <COMMAND>` | One step to execute (repeatable, required). Quoting follows shell rules. |
+
 #### `struct <TEMPLATE>` — Parse binary data using structure templates
 
 Parse and interpret binary data according to YAML structure templates, useful for analyzing file headers, network protocols, and data structures.
@@ -653,8 +683,8 @@ cargo build --release
 | 2 | Search, analyze, diff | ✅ Complete |
 | 3 | Convert, patch, struct | ✅ Complete |
 | 4 | Template system evolution | ✅ Complete |
-| 5 | Bit-level precision | 🔄 In progress |
-| 6 | Command chaining & pipelines | 🔲 Planned |
+| 5 | Bit-level precision | ✅ Complete |
+| 6 | Command chaining & pipelines | ✅ Complete |
 | 7 | Live process memory | 🔲 Planned |
 | 8 | Advanced analysis & intelligence | 🔲 Planned |
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
 
-*Version 0.12.0 | Cross-platform (Windows/Linux/macOS) | x86_64/Arm64 Support*
+*Version 0.13.0 | Cross-platform (Windows/Linux/macOS) | x86_64/Arm64 Support*
 
 Binfiddle is a **developer-focused binary manipulation toolkit** designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, statistical analysis, and custom exploration of binary data across a variety of formats.
 
@@ -434,7 +434,7 @@ fields:
 
 **Dynamic Templates:**
 
-Templates support field references (`$fieldname`), magic variables (`$@prev_end`, `$@file_size`), conditional fields (`when:`), computed fields, bitfields, and counted arrays.
+Templates support field references (`$fieldname`), magic variables (`$@prev_end`, `$@file_size`), conditional fields (`when:`), computed fields, bitfields, counted arrays, and bit-level fields (`bit_offset`/`bit_size`).
 
 ```yaml
 fields:
@@ -652,8 +652,8 @@ cargo build --release
 | 1 | Core read/write/edit | ✅ Complete |
 | 2 | Search, analyze, diff | ✅ Complete |
 | 3 | Convert, patch, struct | ✅ Complete |
-| 4 | Template system evolution | 🔄 In progress |
-| 5 | Bit-level precision | 🔲 Planned |
+| 4 | Template system evolution | ✅ Complete |
+| 5 | Bit-level precision | 🔄 In progress |
 | 6 | Command chaining & pipelines | 🔲 Planned |
 | 7 | Live process memory | 🔲 Planned |
 | 8 | Advanced analysis & intelligence | 🔲 Planned |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
 
-*Version 0.16.0 | Cross-platform (Windows/Linux/macOS) | x86_64/Arm64 Support*
+*Version 0.17.0 | Cross-platform (Windows/Linux/macOS) | x86_64/Arm64 Support*
 
 Binfiddle is a **developer-focused binary manipulation toolkit** designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, statistical analysis, and custom exploration of binary data across a variety of formats.
 
@@ -432,6 +432,10 @@ binfiddle --process-self --address 0x400000 --size 0x1000 search 474343
 # Overwrite 4 bytes in the current process (requires --allow-write)
 binfiddle --process-self --address 0x7ffd12345678 --size 4 \
     --allow-write write 0 DEADBEEF
+
+# Overwrite bytes in another process's writable memory
+binfiddle --pid 1234 --address 0x7f8a1b2c3000 --size 4 \
+    --allow-write write 0 CAFEBABE
 ```
 
 **Process Memory Options:**
@@ -445,7 +449,7 @@ binfiddle --process-self --address 0x7ffd12345678 --size 4 \
 | `--size` | Number of bytes to read or write (hex or decimal). |
 | `--allow-write` | Opt-in required for any process-memory write. |
 
-> **Note:** Cross-process writes are not yet supported; `--allow-write` only works for `--process-self`.
+> **Note:** Cross-process writes require the target region to be writable. Writes to read-only regions are rejected unless a future `--force-writable` option is added.
 
 #### `struct <TEMPLATE>` — Parse binary data using structure templates
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
 
-*Version 0.15.0 | Cross-platform (Windows/Linux/macOS) | x86_64/Arm64 Support*
+*Version 0.16.0 | Cross-platform (Windows/Linux/macOS) | x86_64/Arm64 Support*
 
 Binfiddle is a **developer-focused binary manipulation toolkit** designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, statistical analysis, and custom exploration of binary data across a variety of formats.
 
@@ -39,7 +39,7 @@ Whether you're reverse-engineering firmware, debugging binary protocols, analyzi
 | **Patch** | Apply binary patches (works with diff --format patch output) |
 | **Convert** | Text encoding conversion and line ending normalization |
 | **Chain** | Pipe multiple binfiddle commands together without shell escaping |
-| **Process Memory** | Read memory from the current process via `/proc/self/mem` (Linux, experimental) |
+| **Process Memory** | Read memory from any same-user process via `/proc/<pid>/mem` and list mapped regions (Linux, experimental) |
 | **Struct** | Parse binary data using YAML templates for structure definitions |
 
 ### Key Differentiators
@@ -409,27 +409,43 @@ binfiddle --silent -i data.bin -o out.bin chain \
 |--------|-------------|
 | `--step <COMMAND>` | One step to execute (repeatable, required). Quoting follows shell rules. |
 
-#### `read` from current process memory — Linux experimental
+#### Process memory — Linux experimental
 
-Read bytes from the running `binfiddle` process itself via `/proc/self/mem`. This is a minimal, read-only proof of concept for live process memory inspection.
+Read memory from the current process or any same-user process via `/proc/<pid>/mem`, list mapped memory regions, and write back to the current process with an explicit opt-in.
 
 ```bash
-# Read 16 bytes from a known address in the current process
+# List memory regions of the current process
+binfiddle --process-self --list-regions
+
+# List regions of another process
+binfiddle --pid 1234 --list-regions
+
+# Read 16 bytes from the current process at a known address
 binfiddle --process-self --address 0x7ffd12345678 --size 16 read 0..16
 
-# Search current process memory for a pattern
+# Read from another process
+binfiddle --pid 1234 --address 0x7f8a1b2c3000 --size 16 read 0..16
+
+# Search process memory for a pattern
 binfiddle --process-self --address 0x400000 --size 0x1000 search 474343
+
+# Overwrite 4 bytes in the current process (requires --allow-write)
+binfiddle --process-self --address 0x7ffd12345678 --size 4 \
+    --allow-write write 0 DEADBEEF
 ```
 
 **Process Memory Options:**
 
 | Option | Description |
 |--------|-------------|
-| `--process-self` | Read from `/proc/self/mem` instead of a file or stdin. |
-| `--address` | Base address to read from (hex or decimal). |
-| `--size` | Number of bytes to read (hex or decimal). |
+| `--process-self` | Target the current process. |
+| `--pid <PID>` | Target another process. |
+| `--list-regions` | Print memory regions from `/proc/<pid>/maps`. |
+| `--address` | Base address to read from or write to (hex or decimal). |
+| `--size` | Number of bytes to read or write (hex or decimal). |
+| `--allow-write` | Opt-in required for any process-memory write. |
 
-> **Note:** Writing to process memory is not supported in this version. Use `--output` to save any modified data to a file.
+> **Note:** Cross-process writes are not yet supported; `--allow-write` only works for `--process-self`.
 
 #### `struct <TEMPLATE>` — Parse binary data using structure templates
 
@@ -627,6 +643,7 @@ src/
 ├── main.rs          # CLI entry point and argument parsing
 ├── lib.rs           # Library exports
 ├── error.rs         # Error types (BinfiddleError)
+├── process_memory.rs # Linux process memory helpers
 ├── commands/
 │   ├── mod.rs       # Command trait and exports
 │   ├── read.rs      # Read command
@@ -654,10 +671,12 @@ pub struct BinaryData {
 }
 
 pub enum BinarySource {
-    File(PathBuf),       // Read from file
-    Stdin,               // Read from stdin
-    RawData(Vec<u8>),    // In-memory data
-    MemoryAddress(usize), // Process memory (reserved)
+    File(PathBuf),         // Read from file
+    Stdin,                 // Read from stdin
+    RawData(Vec<u8>),      // In-memory data
+    ProcessSelf { .. },    // Current process memory (/proc/self/mem)
+    Process { .. },        // Another process's memory (/proc/<pid>/mem)
+    MemoryAddress(usize),  // Raw memory address (reserved)
 }
 ```
 
@@ -670,6 +689,7 @@ All operations return `Result<T, BinfiddleError>` with specific error types:
 - `InvalidChunkSize` — Chunk size is 0 or exceeds data
 - `InvalidInput` — Unknown format or invalid input
 - `UnsupportedOperation` — Feature not yet implemented (e.g., memory address access)
+- `ProcessMemoryError` — `/proc/<pid>/mem` access or permission failure
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.70%2B-orange.svg)](https://www.rust-lang.org/)
 
-*Version 0.14.0 | Cross-platform (Windows/Linux/macOS) | x86_64/Arm64 Support*
+*Version 0.15.0 | Cross-platform (Windows/Linux/macOS) | x86_64/Arm64 Support*
 
 Binfiddle is a **developer-focused binary manipulation toolkit** designed for flexibility, modularity, and clarity. It enables inspection, patching, differential analysis, statistical analysis, and custom exploration of binary data across a variety of formats.
 
@@ -39,6 +39,7 @@ Whether you're reverse-engineering firmware, debugging binary protocols, analyzi
 | **Patch** | Apply binary patches (works with diff --format patch output) |
 | **Convert** | Text encoding conversion and line ending normalization |
 | **Chain** | Pipe multiple binfiddle commands together without shell escaping |
+| **Process Memory** | Read memory from the current process via `/proc/self/mem` (Linux, experimental) |
 | **Struct** | Parse binary data using YAML templates for structure definitions |
 
 ### Key Differentiators
@@ -408,6 +409,28 @@ binfiddle --silent -i data.bin -o out.bin chain \
 |--------|-------------|
 | `--step <COMMAND>` | One step to execute (repeatable, required). Quoting follows shell rules. |
 
+#### `read` from current process memory — Linux experimental
+
+Read bytes from the running `binfiddle` process itself via `/proc/self/mem`. This is a minimal, read-only proof of concept for live process memory inspection.
+
+```bash
+# Read 16 bytes from a known address in the current process
+binfiddle --process-self --address 0x7ffd12345678 --size 16 read 0..16
+
+# Search current process memory for a pattern
+binfiddle --process-self --address 0x400000 --size 0x1000 search 474343
+```
+
+**Process Memory Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--process-self` | Read from `/proc/self/mem` instead of a file or stdin. |
+| `--address` | Base address to read from (hex or decimal). |
+| `--size` | Number of bytes to read (hex or decimal). |
+
+> **Note:** Writing to process memory is not supported in this version. Use `--output` to save any modified data to a file.
+
 #### `struct <TEMPLATE>` — Parse binary data using structure templates
 
 Parse and interpret binary data according to YAML structure templates, useful for analyzing file headers, network protocols, and data structures.
@@ -685,7 +708,7 @@ cargo build --release
 | 4 | Template system evolution | ✅ Complete |
 | 5 | Bit-level precision | ✅ Complete |
 | 6 | Command chaining & pipelines | ✅ Complete |
-| 7 | Live process memory | 🔲 Planned |
+| 7 | Live process memory | ✅ v1 Complete (/proc/self read-only) |
 | 8 | Advanced analysis & intelligence | 🔲 Planned |
 
 ## License

--- a/benches/search_benchmarks.rs
+++ b/benches/search_benchmarks.rs
@@ -2,7 +2,8 @@
 //!
 //! Run with: `cargo bench`
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::hint::black_box;
 
 use binfiddle::commands::SearchCommand;
 use binfiddle::utils::parsing::SearchPattern;
@@ -48,10 +49,8 @@ fn bench_exact_search(c: &mut Criterion) {
 
         group.throughput(Throughput::Bytes(*size as u64));
         group.bench_with_input(BenchmarkId::new("sequential", size), &data, |b, data| {
-            let config = make_search_config(
-                SearchPattern::Exact(vec![0xDE, 0xAD, 0xBE, 0xEF]),
-                true,
-            );
+            let config =
+                make_search_config(SearchPattern::Exact(vec![0xDE, 0xAD, 0xBE, 0xEF]), true);
             let cmd = SearchCommand::new(config);
             b.iter(|| {
                 let matches = cmd.search(black_box(data)).unwrap();
@@ -96,10 +95,8 @@ fn bench_regex_search(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(*size as u64));
         group.bench_with_input(BenchmarkId::new("sequential", size), &data, |b, data| {
             // Pattern: Match DEADBEEF as regex
-            let config = make_search_config(
-                SearchPattern::Regex(r"\xDE\xAD\xBE\xEF".to_string()),
-                true,
-            );
+            let config =
+                make_search_config(SearchPattern::Regex(r"\xDE\xAD\xBE\xEF".to_string()), true);
             let cmd = SearchCommand::new(config);
             b.iter(|| {
                 let matches = cmd.search(black_box(data)).unwrap();
@@ -124,10 +121,8 @@ fn bench_parallel_vs_sequential(c: &mut Criterion) {
             BenchmarkId::new("exact_sequential", size),
             &data,
             |b, data| {
-                let config = make_search_config(
-                    SearchPattern::Exact(vec![0xDE, 0xAD, 0xBE, 0xEF]),
-                    true,
-                );
+                let config =
+                    make_search_config(SearchPattern::Exact(vec![0xDE, 0xAD, 0xBE, 0xEF]), true);
                 let cmd = SearchCommand::new(config);
                 b.iter(|| {
                     let matches = cmd.search(black_box(data)).unwrap();
@@ -141,10 +136,8 @@ fn bench_parallel_vs_sequential(c: &mut Criterion) {
             BenchmarkId::new("exact_parallel", size),
             &data,
             |b, data| {
-                let config = make_search_config(
-                    SearchPattern::Exact(vec![0xDE, 0xAD, 0xBE, 0xEF]),
-                    true,
-                );
+                let config =
+                    make_search_config(SearchPattern::Exact(vec![0xDE, 0xAD, 0xBE, 0xEF]), true);
                 let cmd = SearchCommand::new(config);
                 b.iter(|| {
                     let matches = cmd.search_parallel(black_box(data)).unwrap();
@@ -171,21 +164,17 @@ fn bench_parallel_vs_sequential(c: &mut Criterion) {
         );
 
         // Parallel mask search
-        group.bench_with_input(
-            BenchmarkId::new("mask_parallel", size),
-            &data,
-            |b, data| {
-                let config = make_search_config(
-                    SearchPattern::Mask(vec![Some(0xDE), None, Some(0xBE), Some(0xEF)]),
-                    true,
-                );
-                let cmd = SearchCommand::new(config);
-                b.iter(|| {
-                    let matches = cmd.search_parallel(black_box(data)).unwrap();
-                    black_box(matches.len())
-                });
-            },
-        );
+        group.bench_with_input(BenchmarkId::new("mask_parallel", size), &data, |b, data| {
+            let config = make_search_config(
+                SearchPattern::Mask(vec![Some(0xDE), None, Some(0xBE), Some(0xEF)]),
+                true,
+            );
+            let cmd = SearchCommand::new(config);
+            b.iter(|| {
+                let matches = cmd.search_parallel(black_box(data)).unwrap();
+                black_box(matches.len())
+            });
+        });
     }
     group.finish();
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1127,41 +1127,58 @@ binfiddle --silent -i data.bin -o out.bin chain \
 
 ---
 
-### Reading Current Process Memory
+### Process Memory
 
 > **Experimental — Linux only**
 
-The `--process-self` flag reads memory from the current `binfiddle` process via `/proc/self/mem`. This is a minimal, read-only proof of concept intended for exploring live process memory without attaching to another process.
+Process memory support lets you inspect and patch memory via `/proc/<pid>/mem`. You can target the current process with `--process-self` or another same-user process with `--pid <PID>`. The `--list-regions` flag prints the target's memory map so you can pick a valid address and size.
 
 #### Syntax
 
 ```bash
+# List mapped regions
+binfiddle --process-self --list-regions
+binfiddle --pid <PID> --list-regions
+
+# Read memory
 binfiddle --process-self --address <ADDR> --size <N> <COMMAND> [OPTIONS]
+binfiddle --pid <PID> --address <ADDR> --size <N> <COMMAND> [OPTIONS]
 ```
 
-- `--process-self` selects `/proc/self/mem` as the input source.
-- `--address` is the base address to read from (hex or decimal).
-- `--size` is the number of bytes to read (hex or decimal).
-- It conflicts with `--input` and cannot be combined with `chain`.
+- `--process-self` targets `/proc/self/mem`.
+- `--pid <PID>` targets `/proc/<PID>/mem`.
+- `--list-regions` prints regions from `/proc/<PID>/maps` and exits.
+- `--address` and `--size` are hex or decimal.
+- `--allow-write` is required for any write back to process memory.
 
 #### Examples
 
 ```bash
-# Read 16 bytes from address 0x7ffd12345678
+# List memory regions of the current process
+binfiddle --process-self --list-regions
+
+# List regions of another process
+binfiddle --pid 1234 --list-regions
+
+# Read 16 bytes from the current process
 binfiddle --process-self --address 0x7ffd12345678 --size 16 read 0..16
 
-# Search current process memory for a hex pattern
+# Read from another process
+binfiddle --pid 1234 --address 0x7f8a1b2c3000 --size 16 read 0..16
+
+# Search process memory for a hex pattern
 binfiddle --process-self --address 0x400000 --size 0x1000 search 474343
 
-# Analyze entropy of a process memory region
-binfiddle --process-self --address 0x7f0000000 --size 0x10000 analyze entropy
+# Overwrite 4 bytes in the current process (requires --allow-write)
+binfiddle --process-self --address 0x7ffd12345678 --size 4 \
+    --allow-write write 0 DEADBEEF
 ```
 
 #### Limitations
 
-- **Read-only**: `write`, `edit`, and `--in-file` are rejected when `--process-self` is used.
-- **Current process only**: cross-process `/proc/<pid>/mem` is not supported yet.
-- **No region enumeration**: you must supply a valid, accessible address and size.
+- **Cross-process writes are not supported**: `--allow-write` only works with `--process-self`.
+- **Size must stay constant**: `insert` and `remove` are rejected because they would change the memory region size.
+- **No region enumeration for other processes** beyond `--list-regions`; you must supply a valid address and size.
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1143,7 +1143,9 @@ fields:
 |--------|----------|-------------|
 | `name` | Yes | Field identifier |
 | `offset` | Yes* | Byte offset or expression (default: `$@prev_end`) |
-| `size` | Yes* | Size in bytes or expression (omitted for `computed`) |
+| `size` | Yes* | Size in bytes or expression (omitted for `computed` or when `bit_size` is used) |
+| `bit_offset` | No | Bit index inside the byte at `offset` (0-7, default 0) |
+| `bit_size` | No | Size in bits (1-64). When present, the field is read at bit precision |
 | `type` | No | Data type (default: `bytes`) |
 | `assert` | No | Expected hex value for validation |
 | `enum` | No | Map numeric values to names |
@@ -1256,6 +1258,35 @@ fields:
     size: 1
     type: u8
     count: $count
+```
+
+**Bit-level fields**:
+
+Parse packed bit fields at arbitrary positions. Bit ordering follows the
+template `endian`:
+
+- `big` — MSB-first (network protocols, hardware registers).
+- `little` — LSB-first (some file formats).
+
+```yaml
+endian: big
+fields:
+  - name: data_offset
+    offset: 0x0C
+    bit_size: 4
+    type: u8
+
+  - name: reserved
+    offset: 0x0C
+    bit_offset: 4
+    bit_size: 3
+    type: u8
+
+  - name: ns_flag
+    offset: 0x0C
+    bit_offset: 7
+    bit_size: 1
+    type: u8
 ```
 
 #### List Template Fields

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -574,6 +574,7 @@ binfiddle -i <FILE> hash <ALGORITHM> [OPTIONS]
 | `--block-size <N>` | Hash non-overlapping blocks of N bytes (`0` = whole file) | `0` |
 | `--stream` | Read the input incrementally instead of memory-mapping | off |
 | `--read-block-size <N>` | Chunk size when `--stream` is used (supports K/M/G suffixes) | `1M` |
+| `--check <FILE>` | Verify checksums from a file (md5sum/sha256sum format) | — |
 
 #### Examples
 
@@ -598,7 +599,14 @@ binfiddle -i large.bin hash xxhash64
 
 # Stream-hash a file that does not fit in memory
 binfiddle -i huge.bin hash sha256 --stream --read-block-size 64M
+
+# Verify a checksum file (md5sum/sha256sum format)
+binfiddle hash sha256 --check SHA256SUMS
 ```
+
+`--check` expects lines in the standard `DIGEST  FILENAME` format produced by
+GNU coreutils. It prints `OK`/`FAILED` per file and a summary, and exits with
+a non-zero status if any file fails verification.
 
 #### Block-Based Output
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -15,6 +15,7 @@ This guide provides detailed usage instructions, examples, and common workflows 
   - [Converting Encodings](#converting-encodings)
   - [Applying Patches](#applying-patches)
   - [Chaining Commands](#chaining-commands)
+  - [Reading Current Process Memory](#reading-current-process-memory)
   - [Parsing Structures](#parsing-structures)
 - [Input and Output](#input-and-output)
   - [File I/O](#file-io)
@@ -1123,6 +1124,44 @@ binfiddle --silent -i data.bin -o out.bin chain \
 - `chain` bypasses the normal command execution path and launches each step as a subprocess connected by temporary files.
 - If an intermediate step fails or produces no byte output, the chain aborts with a clear error.
 - Use `--silent` to prevent intermediate commands from writing diagnostics to stderr.
+
+---
+
+### Reading Current Process Memory
+
+> **Experimental — Linux only**
+
+The `--process-self` flag reads memory from the current `binfiddle` process via `/proc/self/mem`. This is a minimal, read-only proof of concept intended for exploring live process memory without attaching to another process.
+
+#### Syntax
+
+```bash
+binfiddle --process-self --address <ADDR> --size <N> <COMMAND> [OPTIONS]
+```
+
+- `--process-self` selects `/proc/self/mem` as the input source.
+- `--address` is the base address to read from (hex or decimal).
+- `--size` is the number of bytes to read (hex or decimal).
+- It conflicts with `--input` and cannot be combined with `chain`.
+
+#### Examples
+
+```bash
+# Read 16 bytes from address 0x7ffd12345678
+binfiddle --process-self --address 0x7ffd12345678 --size 16 read 0..16
+
+# Search current process memory for a hex pattern
+binfiddle --process-self --address 0x400000 --size 0x1000 search 474343
+
+# Analyze entropy of a process memory region
+binfiddle --process-self --address 0x7f0000000 --size 0x10000 analyze entropy
+```
+
+#### Limitations
+
+- **Read-only**: `write`, `edit`, and `--in-file` are rejected when `--process-self` is used.
+- **Current process only**: cross-process `/proc/<pid>/mem` is not supported yet.
+- **No region enumeration**: you must supply a valid, accessible address and size.
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1682,6 +1682,14 @@ cat file.bin | binfiddle -i - read 0..16
 cat file.bin | binfiddle read 0..16
 ```
 
+#### Progress Bars
+
+Long-running commands (`hash`, `search --all`, `analyze`, `convert`) show an
+`indicatif` progress bar on stderr when the terminal is interactive. The bar
+displays bytes processed, throughput, and ETA. Progress output is automatically
+suppressed when stderr is not a TTY (e.g. in scripts or pipes) or when
+`--silent` is used, so stdout remains clean for further processing.
+
 #### Writing to Files
 
 ```bash

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1571,6 +1571,36 @@ binfiddle -i input.bin write 0 FF -o output.bin
 binfiddle -i input.bin read 0..16 -o -
 ```
 
+#### Memory-Mapped File Input
+
+File input is memory-mapped using `memmap2` instead of being loaded entirely
+into RAM. This means binfiddle can open files that are larger than available
+memory for read-only operations such as `read`, `search`, `analyze`, and `diff`.
+
+```bash
+# Search a multi-gigabyte firmware image without loading it whole
+binfiddle -i firmware.bin search "7F454C46" --all
+
+# Analyze entropy of a large dump with minimal resident memory
+binfiddle -i memory.dump analyze entropy --block-size 4096
+```
+
+When a command mutates the data (`write`, `edit`), the mapped region is lazily
+copied into an owned in-memory buffer first. Size-changing edits (`insert`,
+`remove`, `replace`) therefore still require enough memory to hold the modified
+data.
+
+#### Large Files
+
+For best results with very large inputs:
+
+- Prefer read-only commands (`read`, `search`, `analyze`, `diff`) — they stream
+  pages from disk through the OS cache on demand.
+- Use `--in-file` or `-o` for writes only when necessary; writes copy the file
+  into memory before modifying it.
+- Avoid running `convert` on files larger than RAM because `convert` reads the
+  entire input to produce a transformed output buffer.
+
 ### Pipeline Usage
 
 Binfiddle is designed for Unix pipelines:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -620,7 +620,7 @@ binfiddle -i <FILE> analyze <ANALYSIS_TYPE> [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--block-size <N>` | Analyze in blocks of N bytes (0 = entire file) [default: 256] |
+| `--block-size <N>` | Analyze in blocks of N bytes (0 = entire file, supports K/M/G suffixes) [default: 256] |
 | `--output-format <FMT>` | Output format: human, csv, json [default: human] |
 | `--range <RANGE>` | Only analyze specified range |
 
@@ -665,6 +665,28 @@ Offset 0x00000400: 4.2000 bits/byte (mixed content)
 Offset 0x00000800: 7.8034 bits/byte (encrypted or random)
 Offset 0x00000c00: 5.8000 bits/byte (mixed content)
 ```
+
+#### Streaming Analyze for Huge Files
+
+When `--block-size` is provided, `analyze` reads the input in blocks of that
+size instead of memory-mapping the whole file. This makes block-based entropy
+and IC analysis practical on files that are larger than RAM. Histogram mode
+accumulates counts across all blocks and still returns a single global result.
+
+```bash
+# Entropy of a 100 GB disk image without paging it all in
+binfiddle -i disk.img analyze entropy --block-size 64M
+
+# Per-block IC analysis of a huge memory dump
+binfiddle -i memory.dump analyze ic --block-size 16M --output-format csv
+```
+
+Limitations of streaming mode:
+
+- `--range` is not supported because the surrounding file offsets are not kept
+  in memory.
+- Process-memory sources (`--process-self`, `--pid`) use the normal in-memory
+  path.
 
 #### Histogram Analysis
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1172,11 +1172,15 @@ binfiddle --process-self --address 0x400000 --size 0x1000 search 474343
 # Overwrite 4 bytes in the current process (requires --allow-write)
 binfiddle --process-self --address 0x7ffd12345678 --size 4 \
     --allow-write write 0 DEADBEEF
+
+# Overwrite bytes in another process's writable memory
+binfiddle --pid 1234 --address 0x7f8a1b2c3000 --size 4 \
+    --allow-write write 0 CAFEBABE
 ```
 
 #### Limitations
 
-- **Cross-process writes are not supported**: `--allow-write` only works with `--process-self`.
+- **Writable regions only**: cross-process writes use `process_vm_writev` and can only modify already-writable memory. Read-only regions are rejected unless a future `--force-writable` option is added.
 - **Size must stay constant**: `insert` and `remove` are rejected because they would change the memory region size.
 - **No region enumeration for other processes** beyond `--list-regions`; you must supply a valid address and size.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1176,11 +1176,20 @@ binfiddle --process-self --address 0x7ffd12345678 --size 4 \
 # Overwrite bytes in another process's writable memory
 binfiddle --pid 1234 --address 0x7f8a1b2c3000 --size 4 \
     --allow-write write 0 CAFEBABE
+
+# Force-write a read-only region in the current process (dangerous)
+binfiddle --process-self --address 0x7ffd12345678 --size 4 \
+    --allow-write --force-writable write 0 DEADBEEF
+
+# Force-write a read-only region in another process (Linux x86_64, dangerous)
+binfiddle --pid 1234 --address 0x7f8a1b2c3000 --size 4 \
+    --allow-write --force-writable write 0 CAFEBABE
 ```
 
 #### Limitations
 
-- **Writable regions only**: cross-process writes use `process_vm_writev` and can only modify already-writable memory. Read-only regions are rejected unless a future `--force-writable` option is added.
+- **Writable regions only by default**: cross-process writes use `process_vm_writev` and can only modify already-writable memory.
+- **`--force-writable`**: uses `mprotect` for `--process-self` and ptrace syscall injection for `--pid` (Linux x86_64 only). It temporarily changes page protection and restores it afterward, but it is inherently risky.
 - **Size must stay constant**: `insert` and `remove` are rejected because they would change the memory region size.
 - **No region enumeration for other processes** beyond `--list-regions`; you must supply a valid address and size.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -10,6 +10,7 @@ This guide provides detailed usage instructions, examples, and common workflows 
   - [Writing Data](#writing-data)
   - [Editing Data](#editing-data)
   - [Searching Data](#searching-data)
+  - [Hashing Data](#hashing-data)
   - [Analyzing Data](#analyzing-data)
   - [Comparing Files (Diff)](#comparing-files-diff)
   - [Converting Encodings](#converting-encodings)
@@ -493,6 +494,29 @@ binfiddle search "[\x20-\x7E]{10,}\x00" --input-format regex -i data.bin --all
 | `--context <N>` | Show N bytes before/after each match |
 | `--no-overlap` | Prevent overlapping matches |
 | `--color <MODE>` | Color output: always, auto, never |
+| `--block-size <SIZE>` | Stream input in blocks (e.g. `64M`, `1G`) |
+
+#### Streaming Search for Very Large Files
+
+By default `search` memory-maps the input. For files that are larger than RAM,
+or when you want to avoid paging the whole file into memory, use
+`--block-size` to stream the input in fixed-size blocks. Boundary matches are
+still detected.
+
+```bash
+# Search a 100 GB file without loading it whole
+binfiddle -i huge.bin search "7F454C46" --all --block-size 64M
+
+# Stop at the first match while streaming
+binfiddle -i huge.bin search "CAFEBABE" --block-size 256M
+```
+
+Limitations of streaming mode:
+
+- Only `hex`, `ascii`, `dec`, `oct`, `bin`, and `mask` patterns are supported.
+  Regex patterns need an unbounded lookback window, so they require the default
+  memory-mapped path.
+- `--context` is disabled because the surrounding bytes are not kept in memory.
 
 #### Search Output Formats
 
@@ -519,6 +543,60 @@ binfiddle search "[\x20-\x7E]{10,}\x00" --input-format regex -i data.bin --all
 ```
 
 ---
+
+
+### Hashing Data
+
+The `hash` command computes common digests over binary data.
+
+#### Supported Algorithms
+
+| Algorithm | Digest Size | Use Case |
+|-----------|-------------|----------|
+| `md5` | 128-bit | Legacy checksums |
+| `sha256` | 256-bit | Cryptographic verification |
+| `blake3` | 256-bit | Fast, modern cryptographic hash |
+| `crc32` | 32-bit | Data integrity / zip-style checksums |
+
+#### Syntax
+
+```bash
+binfiddle -i <FILE> hash <ALGORITHM> [OPTIONS]
+```
+
+#### Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--output-format` | Output encoding (`hex`) | `hex` |
+| `--block-size <N>` | Hash non-overlapping blocks of N bytes (`0` = whole file) | `0` |
+
+#### Examples
+
+```bash
+# SHA-256 of an entire file
+binfiddle -i firmware.bin hash sha256
+
+# MD5 checksum
+binfiddle -i file.bin hash md5
+
+# Per-block CRC32 (useful for finding corrupted regions)
+binfiddle -i disk.img hash crc32 --block-size 4096
+
+# BLAKE3 of a file
+binfiddle -i data.bin hash blake3
+```
+
+#### Block-Based Output
+
+When `--block-size` is set, each block is printed on its own line with its
+starting offset:
+
+```
+0x00000000: a3b2c1d4
+0x00001000: e5f6a7b8
+...
+```
 
 ### Analyzing Data
 
@@ -1642,6 +1720,13 @@ binfiddle -i file.bin --in-file write 0 FF -o out.bin  # ERROR
 cp file.bin file.bin.bak
 binfiddle -i file.bin --in-file write 0 FF
 ```
+
+**In-place `write` uses a mutable memory map.** When `--in-file` is combined
+with the `write` command, binfiddle maps the file read-write and flushes each
+change directly to disk. This avoids copying the entire file into memory, so
+you can patch large files efficiently. Size-changing operations (`insert`,
+`remove`, `replace`) still require an in-memory copy and are written back when
+finished.
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1684,11 +1684,19 @@ cat file.bin | binfiddle read 0..16
 
 #### Progress Bars
 
-Long-running commands (`hash`, `search --all`, `analyze`, `convert`) show an
-`indicatif` progress bar on stderr when the terminal is interactive. The bar
-displays bytes processed, throughput, and ETA. Progress output is automatically
-suppressed when stderr is not a TTY (e.g. in scripts or pipes) or when
-`--silent` is used, so stdout remains clean for further processing.
+Long-running commands (`hash`, `search --all`, `analyze`, `convert`) can show an
+`indicatif` progress bar on stderr when you pass `--progress`. The bar displays
+bytes processed, throughput, and ETA.
+
+```bash
+binfiddle -i huge.bin hash sha256 --stream --read-block-size 64M --progress
+binfiddle -i huge.bin search DEADBEEF --all --block-size 64M --progress
+binfiddle -i huge.bin analyze entropy --block-size 64M --progress
+```
+
+Progress bars are opt-in and are always suppressed when stderr is not a TTY
+(e.g. in scripts or pipes), when `--silent` is used, or inside command chaining,
+so stdout remains clean for further processing.
 
 #### Writing to Files
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -14,6 +14,7 @@ This guide provides detailed usage instructions, examples, and common workflows 
   - [Comparing Files (Diff)](#comparing-files-diff)
   - [Converting Encodings](#converting-encodings)
   - [Applying Patches](#applying-patches)
+  - [Chaining Commands](#chaining-commands)
   - [Parsing Structures](#parsing-structures)
 - [Input and Output](#input-and-output)
   - [File I/O](#file-io)
@@ -47,6 +48,7 @@ binfiddle analyze --help      # Analyze command help
 binfiddle diff --help         # Diff command help
 binfiddle convert --help      # Convert command help
 binfiddle patch --help        # Patch command help
+binfiddle chain --help        # Chain command help
 binfiddle struct --help       # Struct command help
 binfiddle --version           # Version information
 ```
@@ -1074,6 +1076,53 @@ for file in *.bin; do
     binfiddle --output "patched_$file" patch "$file" fix.patch
 done
 ```
+
+---
+
+### Chaining Commands
+
+The `chain` command runs multiple binfiddle commands in sequence, passing the byte output of each step as the input to the next. This avoids shell pipe escaping and makes multi-step workflows explicit and portable.
+
+#### Syntax
+
+```bash
+binfiddle [OPTIONS] chain --step <COMMAND> [--step <COMMAND>] ...
+```
+
+- `--step` is repeatable and required.
+- Each step is parsed with shell quoting rules.
+- Intermediate steps must produce byte output (e.g., `write`, `edit`, `replace`, `convert`).
+- The final step may produce text output (e.g., `read`, `search`, `analyze`).
+
+#### Examples
+
+```bash
+# Replace a header and then patch a byte
+binfiddle -i firmware.bin -o patched.bin chain \
+    --step "edit replace 0..4 44415431" \
+    --step "write 8 00"
+
+# Read result after modification, without shell pipes
+binfiddle -i data.bin chain \
+    --step "edit replace 0..8 1234567890abcdef" \
+    --step "read 0..16"
+
+# Chain from stdin
+printf '\x00\x11\x22\x33' | binfiddle --input - chain \
+    --step "edit replace 0..2 4142" \
+    --step "read 0..4"
+
+# Suppress intermediate diagnostics
+binfiddle --silent -i data.bin -o out.bin chain \
+    --step "edit replace 0..2 9999" \
+    --step "write 0 42"
+```
+
+#### Important Notes
+
+- `chain` bypasses the normal command execution path and launches each step as a subprocess connected by temporary files.
+- If an intermediate step fails or produces no byte output, the chain aborts with a clear error.
+- Use `--silent` to prevent intermediate commands from writing diagnostics to stderr.
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1186,6 +1186,18 @@ binfiddle --pid 1234 --address 0x7f8a1b2c3000 --size 4 \
     --allow-write --force-writable write 0 CAFEBABE
 ```
 
+#### Process Memory Safety
+
+- **`--allow-write` is required** for any write back to process memory. Without it, `write` and `edit` commands are rejected.
+- **`--force-writable` requires `--allow-write`** and temporarily changes read-only pages to writable. Binfiddle restores the original protection after the write, but if the operation is interrupted or an error occurs the target pages may be left writable.
+- **Writes are bounded**: a write that would extend past the mapped region found in `/proc/<pid>/maps` is rejected.
+- **Cross-process access requires ptrace permissions**: reads use `process_vm_readv` and writes use `process_vm_writev` / ptrace injection. On systems with Yama LSM, check `/proc/sys/kernel/yama/ptrace_scope`:
+  - `0` — unrestricted (same-user processes are traceable).
+  - `1` — restricted to parent-child and direct descendants (default on many distributions).
+  - `2` — administrator-only.
+  - `3` — no ptrace allowed.
+- **Use at your own risk**: modifying running process memory can crash the target, corrupt data, or trigger security mitigations. Always target your own processes and prefer writable regions.
+
 #### Limitations
 
 - **Writable regions only by default**: cross-process writes use `process_vm_writev` and can only modify already-writable memory.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1184,6 +1184,14 @@ binfiddle --process-self --address 0x7ffd12345678 --size 4 \
 # Force-write a read-only region in another process (Linux x86_64, dangerous)
 binfiddle --pid 1234 --address 0x7f8a1b2c3000 --size 4 \
     --allow-write --force-writable write 0 CAFEBABE
+
+# Search process memory for an ASCII pattern
+binfiddle --process-self --address 0x400000 --size 0x1000 \
+    search "PASSWORD" --input-format ascii --all
+
+# Read a range that spans an inaccessible page, filling gaps with zeros
+binfiddle --process-self --address 0x7f8a1b2c3000 --size 0x2000 \
+    --zero-fill-inaccessible read 0..0x2000
 ```
 
 #### Process Memory Safety
@@ -1191,6 +1199,7 @@ binfiddle --pid 1234 --address 0x7f8a1b2c3000 --size 4 \
 - **`--allow-write` is required** for any write back to process memory. Without it, `write` and `edit` commands are rejected.
 - **`--force-writable` requires `--allow-write`** and temporarily changes read-only pages to writable. Binfiddle restores the original protection after the write, but if the operation is interrupted or an error occurs the target pages may be left writable.
 - **Writes are bounded**: a write that would extend past the mapped region found in `/proc/<pid>/maps` is rejected.
+- **Inaccessible pages**: by default a read fails if it touches an unmapped or non-readable page. Use `--zero-fill-inaccessible` to replace those bytes with zeros (useful for `read` and `search`) or `--skip-inaccessible` to omit them (read only).
 - **Cross-process access requires ptrace permissions**: reads use `process_vm_readv` and writes use `process_vm_writev` / ptrace injection. On systems with Yama LSM, check `/proc/sys/kernel/yama/ptrace_scope`:
   - `0` — unrestricted (same-user processes are traceable).
   - `1` — restricted to parent-child and direct descendants (default on many distributions).
@@ -1202,6 +1211,7 @@ binfiddle --pid 1234 --address 0x7f8a1b2c3000 --size 4 \
 
 - **Writable regions only by default**: cross-process writes use `process_vm_writev` and can only modify already-writable memory.
 - **`--force-writable`**: uses `mprotect` for `--process-self` and ptrace syscall injection for `--pid` (Linux x86_64 and aarch64). It temporarily changes page protection and restores it afterward, but it is inherently risky.
+- **`--skip-inaccessible` is read-only**: it cannot be used with `search` because reported offsets would no longer match the original process address space.
 - **Size must stay constant**: `insert` and `remove` are rejected because they would change the memory region size.
 - **No region enumeration for other processes** beyond `--list-regions`; you must supply a valid address and size.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -554,9 +554,11 @@ The `hash` command computes common digests over binary data.
 | Algorithm | Digest Size | Use Case |
 |-----------|-------------|----------|
 | `md5` | 128-bit | Legacy checksums |
+| `sha1` | 160-bit | Legacy / git-style verification |
 | `sha256` | 256-bit | Cryptographic verification |
 | `blake3` | 256-bit | Fast, modern cryptographic hash |
 | `crc32` | 32-bit | Data integrity / zip-style checksums |
+| `xxhash64` | 64-bit | Fast non-cryptographic checksum |
 
 #### Syntax
 
@@ -568,8 +570,10 @@ binfiddle -i <FILE> hash <ALGORITHM> [OPTIONS]
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--output-format` | Output encoding (`hex`) | `hex` |
+| `--output-format` | Output encoding (`hex`, `base64`) | `hex` |
 | `--block-size <N>` | Hash non-overlapping blocks of N bytes (`0` = whole file) | `0` |
+| `--stream` | Read the input incrementally instead of memory-mapping | off |
+| `--read-block-size <N>` | Chunk size when `--stream` is used (supports K/M/G suffixes) | `1M` |
 
 #### Examples
 
@@ -585,6 +589,15 @@ binfiddle -i disk.img hash crc32 --block-size 4096
 
 # BLAKE3 of a file
 binfiddle -i data.bin hash blake3
+
+# SHA-1 in base64
+binfiddle -i file.bin hash sha1 --output-format base64
+
+# xxhash64 (very fast)
+binfiddle -i large.bin hash xxhash64
+
+# Stream-hash a file that does not fit in memory
+binfiddle -i huge.bin hash sha256 --stream --read-block-size 64M
 ```
 
 #### Block-Based Output

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1085,7 +1085,7 @@ The `struct` command parses binary data according to YAML structure templates, m
 
 ```bash
 # Parse a binary file using a template
-binfiddle -i firmware.bin struct header_template.yaml
+binfiddle struct header_template.yaml < firmware.bin
 
 # Example output:
 # Structure: Firmware Header
@@ -1142,13 +1142,19 @@ fields:
 | Option | Required | Description |
 |--------|----------|-------------|
 | `name` | Yes | Field identifier |
-| `offset` | Yes | Byte offset (decimal or hex with 0x prefix) |
-| `size` | Yes | Size in bytes |
+| `offset` | Yes* | Byte offset or expression (default: `$@prev_end`) |
+| `size` | Yes* | Size in bytes or expression (omitted for `computed`) |
 | `type` | No | Data type (default: `bytes`) |
 | `assert` | No | Expected hex value for validation |
 | `enum` | No | Map numeric values to names |
 | `description` | No | Field description |
 | `display` | No | Display format override |
+| `when` | No | Conditional expression for parsing |
+| `value` | No | Expression for `computed` fields |
+| `bitfields` | No | Extract bitfields from integer fields |
+| `count` | No | Number of elements for arrays |
+
+* `offset`/`size` can be expressions such as `$filename_length` or `$@prev_end + 4`.
 
 #### Supported Field Types
 
@@ -1165,6 +1171,92 @@ fields:
 | `hex_string` | Variable | Raw bytes as hex (default display) |
 | `string` | Variable | Null-terminated or fixed-length ASCII/UTF-8 |
 | `bytes` | Variable | Raw byte array |
+| `computed` | — | Virtual field calculated from an expression |
+
+#### Advanced Template Features
+
+Templates support a small expression language for dynamic parsing.
+
+**Field References and Magic Variables**:
+
+| Reference | Meaning |
+|-----------|---------|
+| `$fieldname` | Numeric value of a previously parsed field |
+| `$fieldname.subfield` | Bitfield value |
+| `$@current` | Current parse offset |
+| `$@prev_end` | End offset of the previous field |
+| `$@file_size` | Total size of the input data |
+| `$@base` | Base offset of the current template |
+
+**Dynamic offset/size**:
+
+```yaml
+fields:
+  - name: filename_length
+    offset: 0x1A
+    size: 2
+    type: u16
+  - name: filename
+    offset: 0x1E
+    size: $filename_length
+    type: string
+```
+
+**Conditional fields** (`when`):
+
+```yaml
+fields:
+  - name: version
+    offset: 0
+    size: 1
+    type: u8
+  - name: extra
+    offset: 1
+    size: 1
+    type: u8
+    when: $version >= 2
+```
+
+**Computed fields**:
+
+```yaml
+fields:
+  - name: total_size
+    type: computed
+    value: $header_size + $payload_size
+```
+
+**Bitfields**:
+
+```yaml
+fields:
+  - name: flags
+    offset: 0
+    size: 1
+    type: u8
+    bitfields:
+      - name: is_compressed
+        bits: 0
+        type: bool
+      - name: compression_level
+        bits: 2..5
+        type: u8
+```
+
+**Counted arrays**:
+
+```yaml
+fields:
+  - name: count
+    offset: 0
+    size: 1
+    type: u8
+  - name: values
+    offset: 1
+    size: 1
+    type: u8
+    count: $count
+```
 
 #### List Template Fields
 
@@ -1189,24 +1281,24 @@ binfiddle struct elf_header.yaml --list-fields
 
 ```bash
 # Get a single field value
-binfiddle -i /bin/ls struct elf_header.yaml --get e_entry
+binfiddle struct elf_header.yaml --get e_entry < /bin/ls
 # Output: 286416
 
 # Get multiple fields
-binfiddle -i /bin/ls struct elf_header.yaml --get e_type --get e_machine
+binfiddle struct elf_header.yaml --get e_type --get e_machine < /bin/ls
 ```
 
 #### Output Formats
 
 ```bash
 # Human-readable table (default)
-binfiddle -i data.bin struct template.yaml --output-format human
+binfiddle struct template.yaml --output-format human < data.bin
 
 # JSON output
-binfiddle -i data.bin struct template.yaml --output-format json
+binfiddle struct template.yaml --output-format json < data.bin
 
 # YAML output
-binfiddle -i data.bin struct template.yaml --output-format yaml
+binfiddle struct template.yaml --output-format yaml < data.bin
 ```
 
 #### Assertions and Validation
@@ -1744,6 +1836,7 @@ binfiddle --version
 │   oct       336 255 276 357                                     │
 │   bin       11011110 10101101 10111110 11101111                 │
 │   ascii     .... (output only)                                  │
+│   raw       Raw bytes, no formatting (output only)              │
 │   regex     [A-Z]{4} (search only)                              │
 │   mask      DE ?? BE EF (search only)                           │
 ├─────────────────────────────────────────────────────────────────┤
@@ -1755,6 +1848,8 @@ binfiddle --version
 │   --input-format  Input format for values                       │
 │   --chunk-size N  Bits per chunk (default: 8)                   │
 │   --width N       Chunks per line (default: 16)                 │
+│   --show-offset   Show hex address prefix on each line          │
+│   --show-ascii    Show ASCII sidebar (implies --show-offset)    │
 │   --silent        Suppress diff output                          │
 │   --all           Find all matches (search)                     │
 │   --count         Count matches only (search)                   │

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1201,7 +1201,7 @@ binfiddle --pid 1234 --address 0x7f8a1b2c3000 --size 4 \
 #### Limitations
 
 - **Writable regions only by default**: cross-process writes use `process_vm_writev` and can only modify already-writable memory.
-- **`--force-writable`**: uses `mprotect` for `--process-self` and ptrace syscall injection for `--pid` (Linux x86_64 only). It temporarily changes page protection and restores it afterward, but it is inherently risky.
+- **`--force-writable`**: uses `mprotect` for `--process-self` and ptrace syscall injection for `--pid` (Linux x86_64 and aarch64). It temporarily changes page protection and restores it afterward, but it is inherently risky.
 - **Size must stay constant**: `insert` and `remove` are rejected because they would change the memory region size.
 - **No region enumeration for other processes** beyond `--list-regions`; you must supply a valid address and size.
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -30,7 +30,7 @@ Binfiddle is a developer-focused binary manipulation toolkit designed to be flex
 ## Unique Capabilities of binfiddle
 
 - **Seamless CLI Integration:**
-     Binfiddle is engineered to work flawlessly with Unix pipes, making it easy to integrate into custom workflows and automated scripts. For complex transformations, the built-in `chain` command sequences multiple binfiddle steps without the escaping issues of nested shell pipes.
+     Binfiddle is engineered to work flawlessly with Unix pipes, making it easy to integrate into custom workflows and automated scripts. For complex transformations, the built-in `chain` command sequences multiple binfiddle steps without the escaping issues of nested shell pipes. Experimental support for reading the current process's memory via `/proc/self/mem` also enables live inspection from the same command-line interface.
 - **Modular Design:**
      Unlike monolithic tools, binfiddle’s modular approach allows users to perform specific operations (read, write, edit) without launching a full interactive session. This is especially useful when combined with other command-line utilities.
 - **Enhanced Differential Analysis:**

--- a/docs/context.md
+++ b/docs/context.md
@@ -30,7 +30,7 @@ Binfiddle is a developer-focused binary manipulation toolkit designed to be flex
 ## Unique Capabilities of binfiddle
 
 - **Seamless CLI Integration:**
-     Binfiddle is engineered to work flawlessly with Unix pipes, making it easy to integrate into custom workflows and automated scripts. For complex transformations, the built-in `chain` command sequences multiple binfiddle steps without the escaping issues of nested shell pipes. Experimental support for reading the current process's memory via `/proc/self/mem` also enables live inspection from the same command-line interface.
+     Binfiddle is engineered to work flawlessly with Unix pipes, making it easy to integrate into custom workflows and automated scripts. For complex transformations, the built-in `chain` command sequences multiple binfiddle steps without the escaping issues of nested shell pipes. Experimental support for process memory inspection via `/proc/<pid>/mem` also enables live analysis of the current or same-user processes from the same command-line interface.
 - **Modular Design:**
      Unlike monolithic tools, binfiddle’s modular approach allows users to perform specific operations (read, write, edit) without launching a full interactive session. This is especially useful when combined with other command-line utilities.
 - **Enhanced Differential Analysis:**

--- a/docs/context.md
+++ b/docs/context.md
@@ -30,7 +30,7 @@ Binfiddle is a developer-focused binary manipulation toolkit designed to be flex
 ## Unique Capabilities of binfiddle
 
 - **Seamless CLI Integration:**
-     Binfiddle is engineered to work flawlessly with Unix pipes, making it easy to integrate into custom workflows and automated scripts. For instance, diff-ing outputs or chaining multiple binary transformations is straightforward.
+     Binfiddle is engineered to work flawlessly with Unix pipes, making it easy to integrate into custom workflows and automated scripts. For complex transformations, the built-in `chain` command sequences multiple binfiddle steps without the escaping issues of nested shell pipes.
 - **Modular Design:**
      Unlike monolithic tools, binfiddle’s modular approach allows users to perform specific operations (read, write, edit) without launching a full interactive session. This is especially useful when combined with other command-line utilities.
 - **Enhanced Differential Analysis:**

--- a/src/commands/analyze.rs
+++ b/src/commands/analyze.rs
@@ -35,9 +35,11 @@ pub enum AnalysisType {
     IndexOfCoincidence,
 }
 
-impl AnalysisType {
+impl std::str::FromStr for AnalysisType {
+    type Err = BinfiddleError;
+
     /// Parses an analysis type from a string.
-    pub fn from_str(s: &str) -> Result<Self> {
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "entropy" => Ok(AnalysisType::Entropy),
             "histogram" | "hist" => Ok(AnalysisType::Histogram),
@@ -61,9 +63,11 @@ pub enum OutputFormat {
     Json,
 }
 
-impl OutputFormat {
+impl std::str::FromStr for OutputFormat {
+    type Err = BinfiddleError;
+
     /// Parses an output format from a string.
-    pub fn from_str(s: &str) -> Result<Self> {
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "human" | "text" => Ok(OutputFormat::Human),
             "csv" => Ok(OutputFormat::Csv),
@@ -207,7 +211,7 @@ impl AnalyzeCommand {
             .collect();
 
         // Sort by count descending
-        histogram.sort_by(|a, b| b.count.cmp(&a.count));
+        histogram.sort_by_key(|b| std::cmp::Reverse(b.count));
 
         histogram
     }
@@ -225,7 +229,11 @@ impl AnalyzeCommand {
             frequencies[byte as usize] += 1;
         }
 
-        let len = if data.is_empty() { 1.0 } else { data.len() as f64 };
+        let len = if data.is_empty() {
+            1.0
+        } else {
+            data.len() as f64
+        };
 
         (0u16..256)
             .map(|byte_val| {
@@ -403,7 +411,11 @@ impl AnalyzeCommand {
     }
 
     /// Formats histogram results according to the configured output format.
-    pub fn format_histogram_results(&self, histogram: &[ByteFrequency], total_bytes: usize) -> String {
+    pub fn format_histogram_results(
+        &self,
+        histogram: &[ByteFrequency],
+        total_bytes: usize,
+    ) -> String {
         match self.config.format {
             OutputFormat::Human => self.format_histogram_human(histogram, total_bytes),
             OutputFormat::Csv => self.format_histogram_csv(histogram),
@@ -557,7 +569,9 @@ impl AnalyzeCommand {
             if start >= data.len() || end > data.len() || start >= end {
                 return Err(BinfiddleError::InvalidRange(format!(
                     "Invalid range [{}, {}) for data of length {}",
-                    start, end, data.len()
+                    start,
+                    end,
+                    data.len()
                 )));
             }
             &data[start..end]
@@ -781,44 +795,44 @@ mod tests {
     #[test]
     fn test_analysis_type_parsing() {
         assert!(matches!(
-            AnalysisType::from_str("entropy").unwrap(),
+            "entropy".parse::<AnalysisType>().unwrap(),
             AnalysisType::Entropy
         ));
         assert!(matches!(
-            AnalysisType::from_str("HISTOGRAM").unwrap(),
+            "HISTOGRAM".parse::<AnalysisType>().unwrap(),
             AnalysisType::Histogram
         ));
         assert!(matches!(
-            AnalysisType::from_str("ic").unwrap(),
+            "ic".parse::<AnalysisType>().unwrap(),
             AnalysisType::IndexOfCoincidence
         ));
         assert!(matches!(
-            AnalysisType::from_str("ioc").unwrap(),
+            "ioc".parse::<AnalysisType>().unwrap(),
             AnalysisType::IndexOfCoincidence
         ));
-        assert!(AnalysisType::from_str("invalid").is_err());
+        assert!("invalid".parse::<AnalysisType>().is_err());
     }
 
     #[test]
     fn test_output_format_parsing() {
         assert!(matches!(
-            OutputFormat::from_str("human").unwrap(),
+            "human".parse::<OutputFormat>().unwrap(),
             OutputFormat::Human
         ));
         assert!(matches!(
-            OutputFormat::from_str("CSV").unwrap(),
+            "CSV".parse::<OutputFormat>().unwrap(),
             OutputFormat::Csv
         ));
         assert!(matches!(
-            OutputFormat::from_str("json").unwrap(),
+            "json".parse::<OutputFormat>().unwrap(),
             OutputFormat::Json
         ));
-        assert!(OutputFormat::from_str("xml").is_err());
+        assert!("xml".parse::<OutputFormat>().is_err());
     }
 
     #[test]
     fn test_range_restriction() {
-        let data = vec![0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF];
+        let data = [0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF];
         let config = AnalyzeConfig {
             analysis_type: AnalysisType::Entropy,
             block_size: 0,

--- a/src/commands/analyze.rs
+++ b/src/commands/analyze.rs
@@ -23,6 +23,7 @@
 use super::Command;
 use crate::error::{BinfiddleError, Result};
 use crate::BinaryData;
+use std::io::Read;
 
 /// Analysis type to perform.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -594,6 +595,112 @@ impl AnalyzeCommand {
             }
         }
     }
+
+    /// Builds a histogram from aggregated byte counts.
+    fn histogram_from_counts(counts: &[u64; 256], total_bytes: usize) -> Vec<ByteFrequency> {
+        if total_bytes == 0 {
+            return Vec::new();
+        }
+
+        let len = total_bytes as f64;
+        let mut histogram: Vec<ByteFrequency> = counts
+            .iter()
+            .enumerate()
+            .filter(|(_, &count)| count > 0)
+            .map(|(byte_val, &count)| ByteFrequency {
+                byte_value: byte_val as u8,
+                count: count as usize,
+                percentage: (count as f64 / len) * 100.0,
+            })
+            .collect();
+
+        histogram.sort_by_key(|b| std::cmp::Reverse(b.count));
+        histogram
+    }
+
+    /// Streams an analysis over a reader in fixed-size blocks.
+    ///
+    /// The configured `block_size` is used as both the read chunk size and the
+    /// analysis block size. This avoids loading the entire input into memory,
+    /// making block-by-block entropy and IC analysis practical for files that
+    /// are larger than RAM. The histogram analysis type accumulates counts
+    /// across all blocks and returns a single global histogram.
+    pub fn analyze_stream<R: Read>(&self, mut reader: R) -> Result<String> {
+        let block_size = self.config.block_size;
+        if block_size == 0 {
+            return Err(BinfiddleError::InvalidInput(
+                "Streaming analysis requires --block-size > 0".to_string(),
+            ));
+        }
+
+        let mut buffer = vec![0u8; block_size];
+        let mut offset = 0usize;
+
+        match self.config.analysis_type {
+            AnalysisType::Entropy => {
+                let mut results = Vec::new();
+                loop {
+                    let n = reader.read(&mut buffer)?;
+                    if n == 0 {
+                        break;
+                    }
+                    results.push(EntropyResult {
+                        offset,
+                        size: n,
+                        entropy: Self::calculate_entropy(&buffer[..n]),
+                    });
+                    offset += n;
+                }
+                if results.is_empty() {
+                    results.push(EntropyResult {
+                        offset: 0,
+                        size: 0,
+                        entropy: 0.0,
+                    });
+                }
+                Ok(self.format_entropy_results(&results))
+            }
+            AnalysisType::Histogram => {
+                let mut counts = [0u64; 256];
+                let mut total = 0usize;
+                loop {
+                    let n = reader.read(&mut buffer)?;
+                    if n == 0 {
+                        break;
+                    }
+                    for &byte in &buffer[..n] {
+                        counts[byte as usize] += 1;
+                    }
+                    total += n;
+                }
+                let histogram = Self::histogram_from_counts(&counts, total);
+                Ok(self.format_histogram_results(&histogram, total))
+            }
+            AnalysisType::IndexOfCoincidence => {
+                let mut results = Vec::new();
+                loop {
+                    let n = reader.read(&mut buffer)?;
+                    if n == 0 {
+                        break;
+                    }
+                    results.push(IcResult {
+                        offset,
+                        size: n,
+                        ic: Self::calculate_ic(&buffer[..n]),
+                    });
+                    offset += n;
+                }
+                if results.is_empty() {
+                    results.push(IcResult {
+                        offset: 0,
+                        size: 0,
+                        ic: 0.0,
+                    });
+                }
+                Ok(self.format_ic_results(&results))
+            }
+        }
+    }
 }
 
 /// Interprets an entropy value and returns a human-readable description.
@@ -861,5 +968,78 @@ mod tests {
         assert_eq!(interpret_ic(0.01), "possibly compressed");
         assert_eq!(interpret_ic(0.03), "structured binary");
         assert_eq!(interpret_ic(0.07), "text-like patterns");
+    }
+
+    #[test]
+    fn test_stream_entropy_uniform_data() {
+        let data = [0x00u8; 10];
+        let config = AnalyzeConfig {
+            analysis_type: AnalysisType::Entropy,
+            block_size: 4,
+            format: OutputFormat::Human,
+            range: None,
+        };
+        let cmd = AnalyzeCommand::new(config);
+        let output = cmd.analyze_stream(&data[..]).unwrap();
+        assert!(output.contains("Blocks: 3"));
+        assert!(output.contains("0x00000000"));
+    }
+
+    #[test]
+    fn test_stream_entropy_two_value_data() {
+        let mut data = vec![0x00u8; 4];
+        data.extend(vec![0xFFu8; 4]);
+        let config = AnalyzeConfig {
+            analysis_type: AnalysisType::Entropy,
+            block_size: 8,
+            format: OutputFormat::Human,
+            range: None,
+        };
+        let cmd = AnalyzeCommand::new(config);
+        let output = cmd.analyze_stream(&data[..]).unwrap();
+        // Two equally frequent values -> entropy ~1.0
+        assert!(output.contains("1.0000"));
+    }
+
+    #[test]
+    fn test_stream_histogram_accumulates_counts() {
+        let data = [0xAA, 0xAA, 0xBB, 0xCC];
+        let config = AnalyzeConfig {
+            analysis_type: AnalysisType::Histogram,
+            block_size: 2,
+            format: OutputFormat::Human,
+            range: None,
+        };
+        let cmd = AnalyzeCommand::new(config);
+        let output = cmd.analyze_stream(&data[..]).unwrap();
+        assert!(output.contains("Total bytes: 4"));
+        assert!(output.contains("0xaa"));
+    }
+
+    #[test]
+    fn test_stream_ic_per_block() {
+        let data = [0x00, 0x00, 0xFF, 0xFF];
+        let config = AnalyzeConfig {
+            analysis_type: AnalysisType::IndexOfCoincidence,
+            block_size: 2,
+            format: OutputFormat::Human,
+            range: None,
+        };
+        let cmd = AnalyzeCommand::new(config);
+        let output = cmd.analyze_stream(&data[..]).unwrap();
+        assert!(output.contains("0x00000000"));
+        assert!(output.contains("0x00000002"));
+    }
+
+    #[test]
+    fn test_stream_requires_block_size() {
+        let config = AnalyzeConfig {
+            analysis_type: AnalysisType::Entropy,
+            block_size: 0,
+            format: OutputFormat::Human,
+            range: None,
+        };
+        let cmd = AnalyzeCommand::new(config);
+        assert!(cmd.analyze_stream(&[][..]).is_err());
     }
 }

--- a/src/commands/chain.rs
+++ b/src/commands/chain.rs
@@ -1,0 +1,301 @@
+//! Command chaining for binfiddle.
+//!
+//! Provides a `chain` command that executes multiple binfiddle subcommands
+//! sequentially, passing the output of each step as the input to the next.
+//! This avoids shell pipes and escaping issues while reusing the existing CLI.
+//!
+//! Internally, v1 uses subprocesses connected by temporary files. Each step
+//! is a normal binfiddle invocation. This keeps the implementation simple and
+//! ensures every command behaves exactly as it does when run standalone.
+
+use crate::error::{BinfiddleError, Result};
+use std::io::{self, Read, Write};
+use std::process::Command;
+
+/// Executes a chain of binfiddle commands.
+pub struct ChainExecutor;
+
+impl ChainExecutor {
+    /// Executes the given steps in order using the current executable.
+    ///
+    /// - `input_path`: optional initial input file. If `None`, stdin is read.
+    /// - `output_path`: optional final output file. If `None`, final step stdout is forwarded.
+    /// - `silent`: whether to suppress informational stderr from intermediate steps.
+    pub fn execute(
+        steps: &[String],
+        input_path: Option<&str>,
+        output_path: Option<&str>,
+        silent: bool,
+    ) -> Result<()> {
+        let exe = std::env::current_exe().map_err(|e| {
+            BinfiddleError::Io(std::io::Error::new(
+                e.kind(),
+                "Failed to determine current executable path".to_string(),
+            ))
+        })?;
+        Self::execute_with_exe(steps, input_path, output_path, silent, &exe)
+    }
+
+    /// Executes the chain using a specific executable path.
+    pub fn execute_with_exe(
+        steps: &[String],
+        input_path: Option<&str>,
+        output_path: Option<&str>,
+        silent: bool,
+        exe: &std::path::Path,
+    ) -> Result<()> {
+        if steps.is_empty() {
+            return Err(BinfiddleError::InvalidInput(
+                "Chain requires at least one --step".to_string(),
+            ));
+        }
+
+        // Create the initial temporary input file.
+        let output_path = normalize_output_path(output_path);
+        let mut current_input = create_initial_temp(input_path)?;
+
+        for (i, step) in steps.iter().enumerate() {
+            let step_num = i + 1;
+            let is_last = i == steps.len() - 1;
+
+            // Parse the step into arguments, respecting shell-style quoting.
+            let args = shell_words::split(step).map_err(|e| {
+                BinfiddleError::Parse(format!(
+                    "Failed to parse step {} '{}': {}",
+                    step_num, step, e
+                ))
+            })?;
+
+            // Prepare the next temp file for intermediate steps.
+            let next_temp = if !is_last {
+                Some(tempfile::NamedTempFile::new()?)
+            } else {
+                None
+            };
+
+            // Build the subprocess command.
+            let mut cmd = Command::new(exe);
+            cmd.arg("--input").arg(current_input.path());
+
+            if let Some(next) = &next_temp {
+                cmd.arg("--output").arg(next.path());
+            } else if let Some(out) = output_path {
+                cmd.arg("--output").arg(out);
+            }
+
+            if silent {
+                cmd.arg("--silent");
+            }
+
+            cmd.args(&args);
+
+            // Run the step and capture output.
+            let output = cmd.output()?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                return Err(BinfiddleError::ChainStepFailed {
+                    step: step_num,
+                    command: step.clone(),
+                    stderr,
+                });
+            }
+
+            // Forward stderr from every step (diagnostic output).
+            if !silent && !output.stderr.is_empty() {
+                io::stderr().write_all(&output.stderr)?;
+            }
+
+            // Forward stdout only from the final step when no explicit output file.
+            if is_last && output_path.is_none() && !output.stdout.is_empty() {
+                io::stdout().write_all(&output.stdout)?;
+            }
+
+            if let Some(next) = next_temp {
+                // Validate that the intermediate step actually wrote output.
+                let metadata = std::fs::metadata(next.path())?;
+                if metadata.len() == 0 {
+                    return Err(BinfiddleError::InvalidInput(format!(
+                        "Chain step {} ('{}') produced no byte output; intermediate steps must produce bytes (e.g., read, write, edit, convert, patch)",
+                        step_num, step
+                    )));
+                }
+                current_input = next;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Creates the initial temporary file for the chain.
+///
+/// `-` is treated as stdin, matching the normal CLI input convention.
+fn create_initial_temp(input_path: Option<&str>) -> Result<tempfile::NamedTempFile> {
+    let mut temp = tempfile::NamedTempFile::new()?;
+
+    match input_path {
+        Some("-") | None => {
+            let mut stdin = Vec::new();
+            io::stdin().read_to_end(&mut stdin)?;
+            temp.write_all(&stdin)?;
+        }
+        Some(path) => {
+            let data = std::fs::read(path)?;
+            temp.write_all(&data)?;
+        }
+    }
+
+    temp.flush()?;
+    Ok(temp)
+}
+
+/// Normalize `-` output path to `None` so final step stdout is forwarded.
+fn normalize_output_path(output_path: Option<&str>) -> Option<&str> {
+    match output_path {
+        Some("-") | None => None,
+        Some(path) => Some(path),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Locate the built binfiddle binary for use by subprocess tests.
+    ///
+    /// Checks, in order:
+    /// - The `CARGO_BIN_EXE_binfiddle` environment variable set by Cargo for integration tests.
+    /// - The `target/debug/binfiddle` and `target/release/binfiddle` paths relative to the
+    ///   crate manifest directory (works for both `cargo test` and `cargo test --release`).
+    /// - The `binfiddle` executable on `PATH`.
+    fn find_bin_fiddle_binary() -> Option<std::path::PathBuf> {
+        if let Ok(path) = std::env::var("CARGO_BIN_EXE_binfiddle") {
+            let p = std::path::PathBuf::from(path);
+            if p.exists() {
+                return Some(p);
+            }
+        }
+
+        let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let candidates = [
+            manifest_dir.join("target").join("debug").join("binfiddle"),
+            manifest_dir
+                .join("target")
+                .join("release")
+                .join("binfiddle"),
+        ];
+        for candidate in &candidates {
+            if candidate.exists() {
+                return Some(candidate.clone());
+            }
+        }
+
+        // Fall back to PATH.
+        std::env::var_os("PATH").and_then(|paths| {
+            std::env::split_paths(&paths)
+                .map(|p| p.join("binfiddle"))
+                .find(|p| p.exists())
+        })
+    }
+
+    #[test]
+    fn test_empty_steps_rejected() {
+        let result = ChainExecutor::execute(&[], None, None, true);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("at least one --step"));
+    }
+
+    #[test]
+    fn test_two_step_byte_chain() {
+        let exe =
+            find_bin_fiddle_binary().expect("binfiddle binary not found; run cargo build first");
+
+        // Build a test input file and chain two byte-producing commands.
+        let input = tempfile::NamedTempFile::new().unwrap();
+        input
+            .as_file()
+            .write_all(&[0x00, 0x11, 0x22, 0x33])
+            .unwrap();
+        input.as_file().flush().unwrap();
+
+        let output = tempfile::NamedTempFile::new().unwrap();
+
+        ChainExecutor::execute_with_exe(
+            &[
+                "edit replace 0..2 4142".to_string(),
+                "write 2 9999".to_string(),
+            ],
+            Some(input.path().to_str().unwrap()),
+            Some(output.path().to_str().unwrap()),
+            true,
+            &exe,
+        )
+        .unwrap();
+
+        let result = std::fs::read(output.path()).unwrap();
+        assert_eq!(result, vec![0x41, 0x42, 0x99, 0x99]);
+    }
+
+    #[test]
+    fn test_intermediate_step_must_produce_bytes() {
+        let exe =
+            find_bin_fiddle_binary().expect("binfiddle binary not found; run cargo build first");
+
+        // The first step reads bytes, but the second step (search without raw output)
+        // writes text to stdout and leaves --output empty, so the chain should fail.
+        let input = tempfile::NamedTempFile::new().unwrap();
+        input
+            .as_file()
+            .write_all(&[0xDE, 0xAD, 0xBE, 0xEF])
+            .unwrap();
+        input.as_file().flush().unwrap();
+
+        let result = ChainExecutor::execute_with_exe(
+            &[
+                "read 0..4".to_string(),
+                "search DEADBEEF --color never".to_string(),
+                "read 0..2".to_string(),
+            ],
+            Some(input.path().to_str().unwrap()),
+            None,
+            true,
+            &exe,
+        );
+
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("produced no byte output"), "Got: {}", msg);
+    }
+
+    #[test]
+    fn test_invalid_step_parse_fails() {
+        let exe =
+            find_bin_fiddle_binary().expect("binfiddle binary not found; run cargo build first");
+
+        let input = tempfile::NamedTempFile::new().unwrap();
+        input.as_file().write_all(&[0x00]).unwrap();
+        input.as_file().flush().unwrap();
+
+        let result = ChainExecutor::execute_with_exe(
+            &["read --bad-flag".to_string()],
+            Some(input.path().to_str().unwrap()),
+            None,
+            true,
+            &exe,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_shell_quoting_respected() {
+        // Just verify shell_words splits quoted arguments correctly.
+        let args = shell_words::split(r#"search "hello world" --ascii"#).unwrap();
+        assert_eq!(args, vec!["search", "hello world", "--ascii"]);
+    }
+}

--- a/src/commands/convert.rs
+++ b/src/commands/convert.rs
@@ -109,7 +109,9 @@ pub enum NewlineMode {
     Keep,
 }
 
-impl NewlineMode {
+impl std::str::FromStr for NewlineMode {
+    type Err = BinfiddleError;
+
     /// Parse a newline mode from a string.
     ///
     /// # Arguments
@@ -123,7 +125,7 @@ impl NewlineMode {
     /// # Errors
     ///
     /// Returns `InvalidInput` if the mode string is not recognized.
-    pub fn from_str(s: &str) -> Result<Self> {
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "unix" | "lf" => Ok(NewlineMode::Unix),
             "windows" | "crlf" | "dos" => Ok(NewlineMode::Windows),
@@ -135,7 +137,9 @@ impl NewlineMode {
             ))),
         }
     }
+}
 
+impl NewlineMode {
     /// Get the newline byte sequence for this mode.
     pub fn as_bytes(&self) -> &'static [u8] {
         match self {
@@ -161,7 +165,9 @@ pub enum BomMode {
     Keep,
 }
 
-impl BomMode {
+impl std::str::FromStr for BomMode {
+    type Err = BinfiddleError;
+
     /// Parse a BOM mode from a string.
     ///
     /// # Arguments
@@ -175,7 +181,7 @@ impl BomMode {
     /// # Errors
     ///
     /// Returns `InvalidInput` if the mode string is not recognized.
-    pub fn from_str(s: &str) -> Result<Self> {
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "add" | "yes" | "true" => Ok(BomMode::Add),
             "remove" | "strip" | "no" | "false" => Ok(BomMode::Remove),
@@ -202,7 +208,9 @@ pub enum ErrorMode {
     Ignore,
 }
 
-impl ErrorMode {
+impl std::str::FromStr for ErrorMode {
+    type Err = BinfiddleError;
+
     /// Parse an error mode from a string.
     ///
     /// # Arguments
@@ -216,7 +224,7 @@ impl ErrorMode {
     /// # Errors
     ///
     /// Returns `InvalidInput` if the mode string is not recognized.
-    pub fn from_str(s: &str) -> Result<Self> {
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "strict" | "error" | "fail" => Ok(ErrorMode::Strict),
             "replace" | "substitute" => Ok(ErrorMode::Replace),
@@ -578,21 +586,21 @@ mod tests {
 
     #[test]
     fn test_newline_mode_from_str() {
-        assert_eq!(NewlineMode::from_str("unix").unwrap(), NewlineMode::Unix);
-        assert_eq!(NewlineMode::from_str("lf").unwrap(), NewlineMode::Unix);
+        assert_eq!("unix".parse::<NewlineMode>().unwrap(), NewlineMode::Unix);
+        assert_eq!("lf".parse::<NewlineMode>().unwrap(), NewlineMode::Unix);
         assert_eq!(
-            NewlineMode::from_str("windows").unwrap(),
+            "windows".parse::<NewlineMode>().unwrap(),
             NewlineMode::Windows
         );
-        assert_eq!(NewlineMode::from_str("crlf").unwrap(), NewlineMode::Windows);
-        assert_eq!(NewlineMode::from_str("mac").unwrap(), NewlineMode::Mac);
-        assert_eq!(NewlineMode::from_str("cr").unwrap(), NewlineMode::Mac);
-        assert_eq!(NewlineMode::from_str("keep").unwrap(), NewlineMode::Keep);
+        assert_eq!("crlf".parse::<NewlineMode>().unwrap(), NewlineMode::Windows);
+        assert_eq!("mac".parse::<NewlineMode>().unwrap(), NewlineMode::Mac);
+        assert_eq!("cr".parse::<NewlineMode>().unwrap(), NewlineMode::Mac);
+        assert_eq!("keep".parse::<NewlineMode>().unwrap(), NewlineMode::Keep);
     }
 
     #[test]
     fn test_newline_mode_invalid() {
-        assert!(NewlineMode::from_str("invalid").is_err());
+        assert!("invalid".parse::<NewlineMode>().is_err());
     }
 
     // ------------------------------------------------------------------------
@@ -601,15 +609,15 @@ mod tests {
 
     #[test]
     fn test_bom_mode_from_str() {
-        assert_eq!(BomMode::from_str("add").unwrap(), BomMode::Add);
-        assert_eq!(BomMode::from_str("remove").unwrap(), BomMode::Remove);
-        assert_eq!(BomMode::from_str("keep").unwrap(), BomMode::Keep);
-        assert_eq!(BomMode::from_str("strip").unwrap(), BomMode::Remove);
+        assert_eq!("add".parse::<BomMode>().unwrap(), BomMode::Add);
+        assert_eq!("remove".parse::<BomMode>().unwrap(), BomMode::Remove);
+        assert_eq!("keep".parse::<BomMode>().unwrap(), BomMode::Keep);
+        assert_eq!("strip".parse::<BomMode>().unwrap(), BomMode::Remove);
     }
 
     #[test]
     fn test_bom_mode_invalid() {
-        assert!(BomMode::from_str("invalid").is_err());
+        assert!("invalid".parse::<BomMode>().is_err());
     }
 
     // ------------------------------------------------------------------------
@@ -618,14 +626,14 @@ mod tests {
 
     #[test]
     fn test_error_mode_from_str() {
-        assert_eq!(ErrorMode::from_str("strict").unwrap(), ErrorMode::Strict);
-        assert_eq!(ErrorMode::from_str("replace").unwrap(), ErrorMode::Replace);
-        assert_eq!(ErrorMode::from_str("ignore").unwrap(), ErrorMode::Ignore);
+        assert_eq!("strict".parse::<ErrorMode>().unwrap(), ErrorMode::Strict);
+        assert_eq!("replace".parse::<ErrorMode>().unwrap(), ErrorMode::Replace);
+        assert_eq!("ignore".parse::<ErrorMode>().unwrap(), ErrorMode::Ignore);
     }
 
     #[test]
     fn test_error_mode_invalid() {
-        assert!(ErrorMode::from_str("invalid").is_err());
+        assert!("invalid".parse::<ErrorMode>().is_err());
     }
 
     // ------------------------------------------------------------------------

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -51,7 +51,9 @@ pub enum DiffFormat {
     Summary,
 }
 
-impl DiffFormat {
+impl std::str::FromStr for DiffFormat {
+    type Err = BinfiddleError;
+
     /// Parse a format string into a DiffFormat enum.
     ///
     /// # Arguments
@@ -62,7 +64,7 @@ impl DiffFormat {
     ///
     /// # Errors
     /// Returns `InvalidInput` if the format string is not recognized.
-    pub fn from_str(s: &str) -> Result<Self> {
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "simple" => Ok(DiffFormat::Simple),
             "unified" => Ok(DiffFormat::Unified),
@@ -76,7 +78,9 @@ impl DiffFormat {
             ))),
         }
     }
+}
 
+impl DiffFormat {
     /// Automatically selects the best format based on difference density.
     ///
     /// # Arguments
@@ -520,6 +524,7 @@ impl DiffCommand {
     }
 
     /// Formats a single line in unified diff format.
+    #[allow(clippy::too_many_arguments)]
     fn format_unified_line(
         &self,
         output: &mut String,
@@ -576,7 +581,7 @@ impl DiffCommand {
                 output.push(' ');
             } else {
                 let byte = data[offset];
-                let ch = if byte >= 0x20 && byte <= 0x7E {
+                let ch = if (0x20..=0x7E).contains(&byte) {
                     byte as char
                 } else {
                     '.'
@@ -720,6 +725,7 @@ impl DiffCommand {
     }
 
     /// Formats one side of a side-by-side line.
+    #[allow(clippy::too_many_arguments)]
     fn format_side_line(
         &self,
         data: &[u8],
@@ -772,10 +778,10 @@ impl DiffCommand {
         let mut output = String::new();
 
         // Header comment
-        output.push_str(&format!("# binfiddle patch file\n"));
+        output.push_str("# binfiddle patch file\n");
         output.push_str(&format!("# source: {}\n", file1_name));
         output.push_str(&format!("# target: {}\n", file2_name));
-        output.push_str(&format!("# format: OFFSET:OLD_HEX:NEW_HEX\n"));
+        output.push_str("# format: OFFSET:OLD_HEX:NEW_HEX\n");
         output.push_str(&format!("# differences: {}\n", differences.len()));
         output.push_str("#\n");
 
@@ -1008,26 +1014,26 @@ mod tests {
 
     #[test]
     fn test_diff_format_parsing() {
-        assert_eq!(DiffFormat::from_str("simple").unwrap(), DiffFormat::Simple);
+        assert_eq!("simple".parse::<DiffFormat>().unwrap(), DiffFormat::Simple);
         assert_eq!(
-            DiffFormat::from_str("unified").unwrap(),
+            "unified".parse::<DiffFormat>().unwrap(),
             DiffFormat::Unified
         );
         assert_eq!(
-            DiffFormat::from_str("side-by-side").unwrap(),
+            "side-by-side".parse::<DiffFormat>().unwrap(),
             DiffFormat::SideBySide
         );
         assert_eq!(
-            DiffFormat::from_str("sidebyside").unwrap(),
+            "sidebyside".parse::<DiffFormat>().unwrap(),
             DiffFormat::SideBySide
         );
-        assert_eq!(DiffFormat::from_str("patch").unwrap(), DiffFormat::Patch);
+        assert_eq!("patch".parse::<DiffFormat>().unwrap(), DiffFormat::Patch);
         assert_eq!(
-            DiffFormat::from_str("summary").unwrap(),
+            "summary".parse::<DiffFormat>().unwrap(),
             DiffFormat::Summary
         );
-        assert_eq!(DiffFormat::from_str("auto").unwrap(), DiffFormat::Simple); // Placeholder
-        assert!(DiffFormat::from_str("invalid").is_err());
+        assert_eq!("auto".parse::<DiffFormat>().unwrap(), DiffFormat::Simple); // Placeholder
+        assert!("invalid".parse::<DiffFormat>().is_err());
     }
 
     #[test]
@@ -1059,8 +1065,8 @@ mod tests {
         let data1 = vec![0x00; 1000];
         let mut data2 = vec![0x00; 1000];
         // Change 80% of bytes
-        for i in 0..800 {
-            data2[i] = 0xFF;
+        for byte in data2.iter_mut().take(800) {
+            *byte = 0xFF;
         }
 
         let differences = cmd.compare(&data1, &data2);

--- a/src/commands/hash.rs
+++ b/src/commands/hash.rs
@@ -1,23 +1,31 @@
 //! Hash command implementation for binfiddle.
 //!
 //! Computes common digests over binary data, either for the whole input or
-//! block-by-block. Supported algorithms: MD5, SHA-256, BLAKE3, and CRC32.
+//! block-by-block. Supports MD5, SHA-1, SHA-256, BLAKE3, CRC32, and xxhash64,
+//! with hex or base64 output encoding. A streaming mode is available for
+//! incremental hashing of files that do not fit in memory.
 
 use super::Command;
 use crate::error::{BinfiddleError, Result};
 use crate::BinaryData;
+use sha2::Digest;
+use std::io::Read;
 
 /// Hash algorithm to compute.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HashAlgorithm {
     /// MD5 (128-bit)
     Md5,
+    /// SHA-1 (160-bit)
+    Sha1,
     /// SHA-256 (256-bit)
     Sha256,
     /// BLAKE3 (256-bit)
     Blake3,
     /// CRC32/IEEE (32-bit)
     Crc32,
+    /// xxhash64 (64-bit, seed 0)
+    Xxhash64,
 }
 
 impl std::str::FromStr for HashAlgorithm {
@@ -26,11 +34,13 @@ impl std::str::FromStr for HashAlgorithm {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "md5" => Ok(HashAlgorithm::Md5),
+            "sha1" | "sha-1" => Ok(HashAlgorithm::Sha1),
             "sha256" | "sha-256" => Ok(HashAlgorithm::Sha256),
             "blake3" | "blake3-256" => Ok(HashAlgorithm::Blake3),
             "crc32" | "crc-32" => Ok(HashAlgorithm::Crc32),
+            "xxhash64" | "xxh64" => Ok(HashAlgorithm::Xxhash64),
             _ => Err(BinfiddleError::InvalidInput(format!(
-                "Unknown hash algorithm: '{}'. Valid: md5, sha256, blake3, crc32",
+                "Unknown hash algorithm: '{}'. Valid: md5, sha1, sha256, blake3, crc32, xxhash64",
                 s
             ))),
         }
@@ -42,6 +52,8 @@ impl std::str::FromStr for HashAlgorithm {
 pub enum HashOutputFormat {
     /// Lowercase hexadecimal
     Hex,
+    /// Base64 (standard, no padding)
+    Base64,
 }
 
 impl std::str::FromStr for HashOutputFormat {
@@ -50,8 +62,9 @@ impl std::str::FromStr for HashOutputFormat {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "hex" => Ok(HashOutputFormat::Hex),
+            "base64" => Ok(HashOutputFormat::Base64),
             _ => Err(BinfiddleError::InvalidInput(format!(
-                "Unknown hash output format: '{}'. Valid: hex",
+                "Unknown hash output format: '{}'. Valid: hex, base64",
                 s
             ))),
         }
@@ -79,6 +92,47 @@ impl Default for HashConfig {
     }
 }
 
+/// Internal incremental hasher used by the streaming hash path.
+enum IncrementalHasher {
+    Md5(md5::Context),
+    Sha1(sha1::Sha1),
+    Sha256(sha2::Sha256),
+    Blake3(Box<blake3::Hasher>),
+    Crc32(crc32fast::Hasher),
+    Xxhash64(xxhash_rust::xxh64::Xxh64),
+}
+
+impl IncrementalHasher {
+    fn update(&mut self, data: &[u8]) {
+        match self {
+            IncrementalHasher::Md5(ctx) => ctx.consume(data),
+            IncrementalHasher::Sha1(h) => {
+                h.update(data);
+            }
+            IncrementalHasher::Sha256(h) => {
+                h.update(data);
+            }
+            IncrementalHasher::Blake3(h) => {
+                h.update(data);
+            }
+
+            IncrementalHasher::Crc32(h) => h.update(data),
+            IncrementalHasher::Xxhash64(h) => h.update(data),
+        }
+    }
+
+    fn finalize(self) -> Vec<u8> {
+        match self {
+            IncrementalHasher::Md5(ctx) => ctx.compute().0.to_vec(),
+            IncrementalHasher::Sha1(h) => h.finalize().to_vec(),
+            IncrementalHasher::Sha256(h) => h.finalize().to_vec(),
+            IncrementalHasher::Blake3(h) => h.finalize().as_bytes().to_vec(),
+            IncrementalHasher::Crc32(h) => h.finalize().to_be_bytes().to_vec(),
+            IncrementalHasher::Xxhash64(h) => h.digest().to_be_bytes().to_vec(),
+        }
+    }
+}
+
 /// Hash command structure.
 pub struct HashCommand {
     config: HashConfig,
@@ -90,19 +144,51 @@ impl HashCommand {
         Self { config }
     }
 
-    /// Computes the digest of a byte slice.
-    pub fn digest(&self, data: &[u8]) -> String {
+    fn format_bytes(&self, bytes: &[u8]) -> String {
+        match self.config.output_format {
+            HashOutputFormat::Hex => bytes.iter().map(|b| format!("{:02x}", b)).collect(),
+            HashOutputFormat::Base64 => {
+                base64::Engine::encode(&base64::engine::general_purpose::STANDARD, bytes)
+            }
+        }
+    }
+
+    fn new_incremental_hasher(&self) -> IncrementalHasher {
         match self.config.algorithm {
-            HashAlgorithm::Md5 => format!("{:x}", md5::compute(data)),
+            HashAlgorithm::Md5 => IncrementalHasher::Md5(md5::Context::new()),
+            HashAlgorithm::Sha1 => IncrementalHasher::Sha1(sha1::Sha1::new()),
+            HashAlgorithm::Sha256 => IncrementalHasher::Sha256(sha2::Sha256::new()),
+            HashAlgorithm::Blake3 => IncrementalHasher::Blake3(Box::new(blake3::Hasher::new())),
+            HashAlgorithm::Crc32 => IncrementalHasher::Crc32(crc32fast::Hasher::new()),
+            HashAlgorithm::Xxhash64 => {
+                IncrementalHasher::Xxhash64(xxhash_rust::xxh64::Xxh64::new(0))
+            }
+        }
+    }
+
+    fn digest_bytes(&self, data: &[u8]) -> Vec<u8> {
+        match self.config.algorithm {
+            HashAlgorithm::Md5 => md5::compute(data).0.to_vec(),
+            HashAlgorithm::Sha1 => {
+                let mut h = sha1::Sha1::new();
+                h.update(data);
+                h.finalize().to_vec()
+            }
             HashAlgorithm::Sha256 => {
                 use sha2::{Digest, Sha256};
-                let mut hasher = Sha256::new();
-                hasher.update(data);
-                format!("{:x}", hasher.finalize())
+                let mut h = Sha256::new();
+                h.update(data);
+                h.finalize().to_vec()
             }
-            HashAlgorithm::Blake3 => blake3::hash(data).to_hex().to_string(),
-            HashAlgorithm::Crc32 => format!("{:08x}", crc32fast::hash(data)),
+            HashAlgorithm::Blake3 => blake3::hash(data).as_bytes().to_vec(),
+            HashAlgorithm::Crc32 => crc32fast::hash(data).to_be_bytes().to_vec(),
+            HashAlgorithm::Xxhash64 => xxhash_rust::xxh64::xxh64(data, 0).to_be_bytes().to_vec(),
         }
+    }
+
+    /// Computes the digest of a byte slice.
+    pub fn digest(&self, data: &[u8]) -> String {
+        self.format_bytes(&self.digest_bytes(data))
     }
 
     /// Computes the hash over the given data and formats the result.
@@ -126,11 +212,60 @@ impl HashCommand {
 
         Ok(output)
     }
+
+    /// Streams a hash over a reader, avoiding loading the whole input.
+    ///
+    /// If `block_size` is 0, the input is hashed incrementally and a single
+    /// digest is returned. Otherwise, each block-sized chunk is hashed
+    /// independently and output with its offset.
+    pub fn compute_stream<R: Read>(&self, mut reader: R, read_chunk_size: usize) -> Result<String> {
+        if self.config.block_size == 0 {
+            let mut hasher = self.new_incremental_hasher();
+            let mut buffer = vec![0u8; read_chunk_size];
+            loop {
+                let n = reader.read(&mut buffer)?;
+                if n == 0 {
+                    break;
+                }
+                hasher.update(&buffer[..n]);
+            }
+            let digest = hasher.finalize();
+            return Ok(self.format_bytes(&digest));
+        }
+
+        let mut buffer = vec![0u8; self.config.block_size];
+        let mut offset = 0usize;
+        let mut output = String::new();
+        loop {
+            let mut pos = 0usize;
+            while pos < self.config.block_size {
+                match reader.read(&mut buffer[pos..self.config.block_size]) {
+                    Ok(0) => break,
+                    Ok(n) => pos += n,
+                    Err(e) => return Err(e.into()),
+                }
+            }
+            if pos == 0 {
+                break;
+            }
+            if !output.is_empty() {
+                output.push('\n');
+            }
+            output.push_str(&format!(
+                "0x{:08x}: {}",
+                offset,
+                self.format_bytes(&self.digest_bytes(&buffer[..pos]))
+            ));
+            offset += pos;
+        }
+
+        Ok(output)
+    }
 }
 
 impl Command for HashCommand {
     fn execute(&self, _data: &mut BinaryData) -> Result<()> {
-        // The CLI driver calls compute() directly with the byte slice so that
+        // The CLI driver calls compute() or compute_stream() directly so that
         // it can avoid a full copy for file-backed data.
         Ok(())
     }
@@ -147,6 +282,18 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(cmd.digest(b""), "d41d8cd98f00b204e9800998ecf8427e");
+    }
+
+    #[test]
+    fn test_sha1_known_value() {
+        let cmd = HashCommand::new(HashConfig {
+            algorithm: HashAlgorithm::Sha1,
+            ..Default::default()
+        });
+        assert_eq!(
+            cmd.digest(b"hello"),
+            "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"
+        );
     }
 
     #[test]
@@ -184,6 +331,26 @@ mod tests {
     }
 
     #[test]
+    fn test_xxhash64_known_value() {
+        let cmd = HashCommand::new(HashConfig {
+            algorithm: HashAlgorithm::Xxhash64,
+            ..Default::default()
+        });
+        // xxhash64 with seed 0 of "hello" is 0x26c7827d889f6da3
+        assert_eq!(cmd.digest(b"hello"), "26c7827d889f6da3");
+    }
+
+    #[test]
+    fn test_base64_output() {
+        let cmd = HashCommand::new(HashConfig {
+            algorithm: HashAlgorithm::Md5,
+            output_format: HashOutputFormat::Base64,
+            ..Default::default()
+        });
+        assert_eq!(cmd.digest(b"hello"), "XUFAKrxLKna5cZ2REBfFkg==");
+    }
+
+    #[test]
     fn test_block_hashing() {
         let cmd = HashCommand::new(HashConfig {
             algorithm: HashAlgorithm::Crc32,
@@ -199,15 +366,47 @@ mod tests {
     }
 
     #[test]
+    fn test_stream_whole_file_matches_digest() {
+        let cmd = HashCommand::new(HashConfig {
+            algorithm: HashAlgorithm::Sha256,
+            ..Default::default()
+        });
+        let data = b"hello world";
+        let streamed = cmd.compute_stream(&data[..], 4).unwrap();
+        assert_eq!(streamed, cmd.digest(data));
+    }
+
+    #[test]
+    fn test_stream_block_hashing() {
+        let cmd = HashCommand::new(HashConfig {
+            algorithm: HashAlgorithm::Crc32,
+            block_size: 3,
+            ..Default::default()
+        });
+        let streamed = cmd.compute_stream(&b"123456789"[..], 5).unwrap();
+        assert_eq!(streamed, cmd.compute(b"123456789").unwrap());
+    }
+
+    #[test]
     fn test_algorithm_parse() {
         assert_eq!(
             "sha256".parse::<HashAlgorithm>().unwrap(),
             HashAlgorithm::Sha256
         );
         assert_eq!(
-            "SHA-256".parse::<HashAlgorithm>().unwrap(),
-            HashAlgorithm::Sha256
+            "xxhash64".parse::<HashAlgorithm>().unwrap(),
+            HashAlgorithm::Xxhash64
         );
         assert!("unknown".parse::<HashAlgorithm>().is_err());
+    }
+
+    #[test]
+    fn test_output_format_parse() {
+        assert_eq!(
+            "base64".parse::<HashOutputFormat>().unwrap(),
+            HashOutputFormat::Base64
+        );
+        assert!("hex".parse::<HashOutputFormat>().is_ok());
+        assert!("unknown".parse::<HashOutputFormat>().is_err());
     }
 }

--- a/src/commands/hash.rs
+++ b/src/commands/hash.rs
@@ -1,0 +1,213 @@
+//! Hash command implementation for binfiddle.
+//!
+//! Computes common digests over binary data, either for the whole input or
+//! block-by-block. Supported algorithms: MD5, SHA-256, BLAKE3, and CRC32.
+
+use super::Command;
+use crate::error::{BinfiddleError, Result};
+use crate::BinaryData;
+
+/// Hash algorithm to compute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HashAlgorithm {
+    /// MD5 (128-bit)
+    Md5,
+    /// SHA-256 (256-bit)
+    Sha256,
+    /// BLAKE3 (256-bit)
+    Blake3,
+    /// CRC32/IEEE (32-bit)
+    Crc32,
+}
+
+impl std::str::FromStr for HashAlgorithm {
+    type Err = BinfiddleError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "md5" => Ok(HashAlgorithm::Md5),
+            "sha256" | "sha-256" => Ok(HashAlgorithm::Sha256),
+            "blake3" | "blake3-256" => Ok(HashAlgorithm::Blake3),
+            "crc32" | "crc-32" => Ok(HashAlgorithm::Crc32),
+            _ => Err(BinfiddleError::InvalidInput(format!(
+                "Unknown hash algorithm: '{}'. Valid: md5, sha256, blake3, crc32",
+                s
+            ))),
+        }
+    }
+}
+
+/// Output encoding for the digest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HashOutputFormat {
+    /// Lowercase hexadecimal
+    Hex,
+}
+
+impl std::str::FromStr for HashOutputFormat {
+    type Err = BinfiddleError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "hex" => Ok(HashOutputFormat::Hex),
+            _ => Err(BinfiddleError::InvalidInput(format!(
+                "Unknown hash output format: '{}'. Valid: hex",
+                s
+            ))),
+        }
+    }
+}
+
+/// Configuration for hash operations.
+#[derive(Debug, Clone)]
+pub struct HashConfig {
+    /// Hash algorithm to use
+    pub algorithm: HashAlgorithm,
+    /// Output encoding
+    pub output_format: HashOutputFormat,
+    /// Block size for block-based hashing (0 = whole file)
+    pub block_size: usize,
+}
+
+impl Default for HashConfig {
+    fn default() -> Self {
+        Self {
+            algorithm: HashAlgorithm::Sha256,
+            output_format: HashOutputFormat::Hex,
+            block_size: 0,
+        }
+    }
+}
+
+/// Hash command structure.
+pub struct HashCommand {
+    config: HashConfig,
+}
+
+impl HashCommand {
+    /// Creates a new HashCommand with the given configuration.
+    pub fn new(config: HashConfig) -> Self {
+        Self { config }
+    }
+
+    /// Computes the digest of a byte slice.
+    pub fn digest(&self, data: &[u8]) -> String {
+        match self.config.algorithm {
+            HashAlgorithm::Md5 => format!("{:x}", md5::compute(data)),
+            HashAlgorithm::Sha256 => {
+                use sha2::{Digest, Sha256};
+                let mut hasher = Sha256::new();
+                hasher.update(data);
+                format!("{:x}", hasher.finalize())
+            }
+            HashAlgorithm::Blake3 => blake3::hash(data).to_hex().to_string(),
+            HashAlgorithm::Crc32 => format!("{:08x}", crc32fast::hash(data)),
+        }
+    }
+
+    /// Computes the hash over the given data and formats the result.
+    ///
+    /// If `block_size` is 0, the whole input is hashed once. Otherwise, the
+    /// input is split into non-overlapping blocks of that size and each block
+    /// is hashed separately.
+    pub fn compute(&self, data: &[u8]) -> Result<String> {
+        if self.config.block_size == 0 {
+            return Ok(self.digest(data));
+        }
+
+        let mut output = String::new();
+        for (i, chunk) in data.chunks(self.config.block_size).enumerate() {
+            if i > 0 {
+                output.push('\n');
+            }
+            let offset = i * self.config.block_size;
+            output.push_str(&format!("0x{:08x}: {}", offset, self.digest(chunk)));
+        }
+
+        Ok(output)
+    }
+}
+
+impl Command for HashCommand {
+    fn execute(&self, _data: &mut BinaryData) -> Result<()> {
+        // The CLI driver calls compute() directly with the byte slice so that
+        // it can avoid a full copy for file-backed data.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_md5_empty() {
+        let cmd = HashCommand::new(HashConfig {
+            algorithm: HashAlgorithm::Md5,
+            ..Default::default()
+        });
+        assert_eq!(cmd.digest(b""), "d41d8cd98f00b204e9800998ecf8427e");
+    }
+
+    #[test]
+    fn test_sha256_known_value() {
+        let cmd = HashCommand::new(HashConfig {
+            algorithm: HashAlgorithm::Sha256,
+            ..Default::default()
+        });
+        assert_eq!(
+            cmd.digest(b"hello"),
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn test_blake3_known_value() {
+        let cmd = HashCommand::new(HashConfig {
+            algorithm: HashAlgorithm::Blake3,
+            ..Default::default()
+        });
+        assert_eq!(
+            cmd.digest(b"hello"),
+            "ea8f163db38682925e4491c5e58d4bb3506ef8c14eb78a86e908c5624a67200f"
+        );
+    }
+
+    #[test]
+    fn test_crc32_known_value() {
+        let cmd = HashCommand::new(HashConfig {
+            algorithm: HashAlgorithm::Crc32,
+            ..Default::default()
+        });
+        // CRC32 of the bytes "123456789" is 0xcbf43926
+        assert_eq!(cmd.digest(b"123456789"), "cbf43926");
+    }
+
+    #[test]
+    fn test_block_hashing() {
+        let cmd = HashCommand::new(HashConfig {
+            algorithm: HashAlgorithm::Crc32,
+            block_size: 3,
+            ..Default::default()
+        });
+        let output = cmd.compute(b"123456789").unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].starts_with("0x00000000:"));
+        assert!(lines[1].starts_with("0x00000003:"));
+        assert!(lines[2].starts_with("0x00000006:"));
+    }
+
+    #[test]
+    fn test_algorithm_parse() {
+        assert_eq!(
+            "sha256".parse::<HashAlgorithm>().unwrap(),
+            HashAlgorithm::Sha256
+        );
+        assert_eq!(
+            "SHA-256".parse::<HashAlgorithm>().unwrap(),
+            HashAlgorithm::Sha256
+        );
+        assert!("unknown".parse::<HashAlgorithm>().is_err());
+    }
+}

--- a/src/commands/hash.rs
+++ b/src/commands/hash.rs
@@ -9,7 +9,9 @@ use super::Command;
 use crate::error::{BinfiddleError, Result};
 use crate::BinaryData;
 use sha2::Digest;
+use std::fs::File;
 use std::io::Read;
+use std::path::{Path, PathBuf};
 
 /// Hash algorithm to compute.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -261,6 +263,123 @@ impl HashCommand {
 
         Ok(output)
     }
+
+    /// Streams a hash and returns the raw digest bytes.
+    fn compute_stream_raw<R: Read>(
+        &self,
+        mut reader: R,
+        read_chunk_size: usize,
+    ) -> Result<Vec<u8>> {
+        let mut hasher = self.new_incremental_hasher();
+        let mut buffer = vec![0u8; read_chunk_size];
+        loop {
+            let n = reader.read(&mut buffer)?;
+            if n == 0 {
+                break;
+            }
+            hasher.update(&buffer[..n]);
+        }
+        Ok(hasher.finalize())
+    }
+
+    /// Verifies checksums from a file in md5sum/sha256sum format.
+    ///
+    /// Returns a report string and a boolean indicating whether every entry
+    /// passed. The report uses `OK`/`FAILED` lines followed by a summary.
+    pub fn check(&self, checksum_file: &Path, read_chunk_size: usize) -> Result<(String, bool)> {
+        if self.config.block_size != 0 {
+            return Err(BinfiddleError::InvalidInput(
+                "--check requires --block-size 0 (whole file)".to_string(),
+            ));
+        }
+
+        let base_dir = checksum_file.parent().unwrap_or_else(|| Path::new("."));
+        let contents = std::fs::read_to_string(checksum_file)?;
+
+        let mut passed = 0usize;
+        let mut failed = 0usize;
+        let mut report = String::new();
+
+        for line in contents.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+                continue;
+            }
+
+            let (expected_hex, filename) = parse_checksum_line(line)?;
+            let expected = hex_to_bytes(expected_hex).map_err(|e| {
+                BinfiddleError::InvalidInput(format!("Invalid digest on line '{}': {}", line, e))
+            })?;
+
+            let file_path = if Path::new(filename).is_absolute() {
+                PathBuf::from(filename)
+            } else {
+                base_dir.join(filename)
+            };
+
+            let file = File::open(&file_path)?;
+            let actual = self.compute_stream_raw(file, read_chunk_size)?;
+
+            let status = if actual == expected {
+                passed += 1;
+                "OK"
+            } else {
+                failed += 1;
+                "FAILED"
+            };
+
+            if !report.is_empty() {
+                report.push('\n');
+            }
+            report.push_str(&format!("{}: {}", filename, status));
+        }
+
+        if !report.is_empty() {
+            report.push('\n');
+        }
+        report.push_str(&format!("{} passed, {} failed", passed, failed));
+
+        Ok((report, failed == 0))
+    }
+}
+
+/// Parses a single checksum-file line into `(digest, filename)`.
+///
+/// Supports the GNU coreutils format `DIGEST  FILENAME` (two spaces) with an
+/// optional binary marker (`*`) before the filename, and falls back to
+/// whitespace splitting.
+fn parse_checksum_line(line: &str) -> Result<(&str, &str)> {
+    if let Some(pos) = line.find("  ") {
+        let (digest, rest) = line.split_at(pos);
+        let filename = rest.trim_start().trim_start_matches('*');
+        return Ok((digest.trim(), filename));
+    }
+
+    let mut parts = line.split_whitespace();
+    let digest = parts.next().ok_or_else(|| {
+        BinfiddleError::InvalidInput(format!("Malformed checksum line: '{}'", line))
+    })?;
+    let filename = parts.next().ok_or_else(|| {
+        BinfiddleError::InvalidInput(format!("Malformed checksum line: '{}'", line))
+    })?;
+
+    Ok((digest, filename))
+}
+
+/// Converts a lowercase/uppercase hex string into its raw bytes.
+fn hex_to_bytes(hex: &str) -> std::result::Result<Vec<u8>, String> {
+    let hex = hex.trim();
+    if !hex.len().is_multiple_of(2) {
+        return Err("odd number of hex digits".to_string());
+    }
+
+    (0..hex.len())
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&hex[i..i + 2], 16)
+                .map_err(|e| format!("invalid hex pair '{}': {}", &hex[i..i + 2], e))
+        })
+        .collect()
 }
 
 impl Command for HashCommand {
@@ -408,5 +527,66 @@ mod tests {
         );
         assert!("hex".parse::<HashOutputFormat>().is_ok());
         assert!("unknown".parse::<HashOutputFormat>().is_err());
+    }
+
+    #[test]
+    fn test_check_passes_and_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_a = dir.path().join("a.txt");
+        let file_b = dir.path().join("b.txt");
+        std::fs::write(&file_a, b"hello").unwrap();
+        std::fs::write(&file_b, b"world").unwrap();
+
+        let checksum_file = dir.path().join("checksums.sha256");
+        let cmd = HashCommand::new(HashConfig {
+            algorithm: HashAlgorithm::Sha256,
+            ..Default::default()
+        });
+        let good = cmd.digest(b"hello");
+        let bad = "0".repeat(64);
+        std::fs::write(&checksum_file, format!("{}  a.txt\n{}  b.txt\n", good, bad)).unwrap();
+
+        let (report, ok) = cmd.check(&checksum_file, 1024).unwrap();
+        assert!(!ok);
+        assert!(report.contains("a.txt: OK"));
+        assert!(report.contains("b.txt: FAILED"));
+        assert!(report.contains("1 passed, 1 failed"));
+    }
+
+    #[test]
+    fn test_check_ignores_comments_and_empty_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("data.bin");
+        std::fs::write(&file, b"data").unwrap();
+
+        let checksum_file = dir.path().join("checksums.md5");
+        let cmd = HashCommand::new(HashConfig {
+            algorithm: HashAlgorithm::Md5,
+            ..Default::default()
+        });
+        let digest = cmd.digest(b"data");
+        std::fs::write(
+            &checksum_file,
+            format!("# this is a comment\n\n{}  data.bin\n", digest),
+        )
+        .unwrap();
+
+        let (report, ok) = cmd.check(&checksum_file, 1024).unwrap();
+        assert!(ok);
+        assert!(report.contains("data.bin: OK"));
+    }
+
+    #[test]
+    fn test_check_rejects_block_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let checksum_file = dir.path().join("checksums.sha256");
+        std::fs::write(&checksum_file, b"dummy").unwrap();
+
+        let cmd = HashCommand::new(HashConfig {
+            algorithm: HashAlgorithm::Sha256,
+            block_size: 4,
+            ..Default::default()
+        });
+        assert!(cmd.check(&checksum_file, 1024).is_err());
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@
 use crate::{BinaryData, Result};
 
 pub mod analyze;
+pub mod chain;
 pub mod convert;
 pub mod diff;
 pub mod edit;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod patch;
 pub mod read;
 pub mod search;
 pub mod struct_cmd;
+pub mod struct_expr;
 pub mod write;
 
 pub use analyze::{
@@ -21,8 +22,8 @@ pub use patch::{PatchCommand, PatchConfig, PatchEntry, PatchResult};
 pub use read::ReadCommand;
 pub use search::{SearchCommand, SearchConfig, SearchMatch};
 pub use struct_cmd::{
-    Endianness, FieldDefinition, FieldType, ParsedField, ParsedStruct, StructCommand, StructConfig,
-    StructOutputFormat, StructTemplate,
+    BitfieldDefinition, Endianness, FieldDefinition, FieldType, ParsedField, ParsedStruct,
+    StructCommand, StructConfig, StructOutputFormat, StructTemplate, ValueOrExpression,
 };
 pub use write::WriteCommand;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod edit;
 pub mod patch;
 pub mod read;
 pub mod search;
+pub mod struct_bits;
 pub mod struct_cmd;
 pub mod struct_expr;
 pub mod write;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod chain;
 pub mod convert;
 pub mod diff;
 pub mod edit;
+pub mod hash;
 pub mod patch;
 pub mod read;
 pub mod search;
@@ -20,6 +21,7 @@ pub use analyze::{
 pub use convert::{parse_encoding, BomMode, ConvertCommand, ConvertConfig, ErrorMode, NewlineMode};
 pub use diff::{parse_ignore_ranges, DiffCommand, DiffConfig, DiffEntry, DiffFormat};
 pub use edit::{EditCommand, EditOperation};
+pub use hash::{HashAlgorithm, HashCommand, HashConfig, HashOutputFormat};
 pub use patch::{PatchCommand, PatchConfig, PatchEntry, PatchResult};
 pub use read::ReadCommand;
 pub use search::{SearchCommand, SearchConfig, SearchMatch};

--- a/src/commands/patch.rs
+++ b/src/commands/patch.rs
@@ -162,9 +162,9 @@ impl PatchCommand {
             }
 
             // Parse the line: OFFSET:OLD_HEX:NEW_HEX
-            let entry = self.parse_patch_line(line).map_err(|e| {
-                BinfiddleError::Parse(format!("Line {}: {}", line_num + 1, e))
-            })?;
+            let entry = self
+                .parse_patch_line(line)
+                .map_err(|e| BinfiddleError::Parse(format!("Line {}: {}", line_num + 1, e)))?;
 
             entries.push(entry);
         }
@@ -215,9 +215,8 @@ impl PatchCommand {
             (s, 16)
         };
 
-        usize::from_str_radix(s, radix).map_err(|e| {
-            BinfiddleError::Parse(format!("Invalid offset '{}': {}", s, e))
-        })
+        usize::from_str_radix(s, radix)
+            .map_err(|e| BinfiddleError::Parse(format!("Invalid offset '{}': {}", s, e)))
     }
 
     /// Parses a hex string into bytes.
@@ -238,16 +237,14 @@ impl PatchCommand {
         let s: String = s.chars().filter(|c| !c.is_whitespace()).collect();
 
         // Ensure even length
-        if s.len() % 2 != 0 {
+        if !s.len().is_multiple_of(2) {
             return Err(BinfiddleError::Parse(format!(
                 "Hex string '{}' has odd length",
                 s
             )));
         }
 
-        hex::decode(&s).map_err(|e| {
-            BinfiddleError::Parse(format!("Invalid hex '{}': {}", s, e))
-        })
+        hex::decode(&s).map_err(|e| BinfiddleError::Parse(format!("Invalid hex '{}': {}", s, e)))
     }
 
     /// Validates that a patch can be applied to the given data.
@@ -362,7 +359,11 @@ impl PatchCommand {
     ///
     /// Currently, only same-length changes are supported for simplicity.
     /// Different-length changes are reported as errors.
-    pub fn apply(&self, data: &[u8], entries: &[PatchEntry]) -> Result<(Vec<u8>, Vec<PatchResult>)> {
+    pub fn apply(
+        &self,
+        data: &[u8],
+        entries: &[PatchEntry],
+    ) -> Result<(Vec<u8>, Vec<PatchResult>)> {
         let mut result_data = data.to_vec();
         let mut results = Vec::new();
 

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -20,6 +20,7 @@ use crate::{BinaryData, ColorMode};
 use memchr::memmem;
 use rayon::prelude::*;
 use regex::bytes::Regex;
+use std::io::Read;
 
 /// Minimum file size (in bytes) to trigger parallel search.
 /// Below this threshold, sequential search is typically faster due to parallelization overhead.
@@ -100,6 +101,24 @@ impl SearchCommand {
             SearchPattern::Exact(needle) => self.search_exact(data, needle),
             SearchPattern::Regex(pattern) => self.search_regex(data, pattern),
             SearchPattern::Mask(mask) => self.search_mask(data, mask),
+        }
+    }
+
+    /// Streams a search over a reader in fixed-size blocks.
+    ///
+    /// This avoids loading the entire input into memory. The input is read in
+    /// blocks of `block_size` bytes, with an overlap region large enough to
+    /// catch matches that span block boundaries.
+    ///
+    /// Regex patterns are not supported in streaming mode because a regex may
+    /// need an arbitrarily large lookback window.
+    pub fn search_stream<R: Read>(&self, reader: R, block_size: usize) -> Result<Vec<SearchMatch>> {
+        match &self.config.pattern {
+            SearchPattern::Exact(needle) => self.search_exact_stream(reader, needle, block_size),
+            SearchPattern::Mask(mask) => self.search_mask_stream(reader, mask, block_size),
+            SearchPattern::Regex(_) => Err(BinfiddleError::UnsupportedOperation(
+                "Streaming search is not supported for regex patterns".to_string(),
+            )),
         }
     }
 
@@ -227,6 +246,171 @@ impl SearchCommand {
         }
 
         true
+    }
+
+    /// Streams an exact search over a reader.
+    fn search_exact_stream<R: Read>(
+        &self,
+        mut reader: R,
+        needle: &[u8],
+        block_size: usize,
+    ) -> Result<Vec<SearchMatch>> {
+        let needle_len = needle.len();
+        if needle_len == 0 {
+            return Err(BinfiddleError::InvalidInput(
+                "Search pattern cannot be empty".to_string(),
+            ));
+        }
+
+        let overlap = needle_len.saturating_sub(1);
+        let effective_block = block_size.max(needle_len);
+        let buf_len = effective_block + overlap;
+        let mut buf = vec![0u8; buf_len];
+        let mut pos = 0usize;
+        let mut eof = false;
+        let mut global_offset = 0usize;
+        let mut matches = Vec::new();
+        let finder = memmem::Finder::new(needle);
+
+        loop {
+            while pos < buf_len && !eof {
+                match reader.read(&mut buf[pos..buf_len]) {
+                    Ok(0) => eof = true,
+                    Ok(n) => pos += n,
+                    Err(e) => return Err(e.into()),
+                }
+            }
+
+            if pos == 0 {
+                break;
+            }
+
+            let search_limit = if eof {
+                pos
+            } else {
+                pos.saturating_sub(overlap)
+            };
+            let mut search_start = 0;
+
+            while search_start < pos {
+                match finder.find(&buf[search_start..pos]) {
+                    Some(relative) => {
+                        let absolute = search_start + relative;
+                        let in_overlap = !eof && absolute >= search_limit;
+
+                        if !in_overlap {
+                            matches.push(SearchMatch {
+                                offset: global_offset + absolute,
+                                data: needle.to_vec(),
+                            });
+
+                            if !self.config.find_all {
+                                return Ok(matches);
+                            }
+                        }
+
+                        search_start = if self.config.no_overlap {
+                            absolute + needle_len
+                        } else {
+                            absolute + 1
+                        };
+                    }
+                    None => break,
+                }
+            }
+
+            if eof {
+                break;
+            }
+
+            let consumed = search_limit;
+            buf.copy_within(consumed..pos, 0);
+            global_offset += consumed;
+            pos -= consumed;
+        }
+
+        Ok(matches)
+    }
+
+    /// Streams a mask search over a reader.
+    fn search_mask_stream<R: Read>(
+        &self,
+        mut reader: R,
+        mask: &[Option<u8>],
+        block_size: usize,
+    ) -> Result<Vec<SearchMatch>> {
+        let mask_len = mask.len();
+        if mask_len == 0 {
+            return Err(BinfiddleError::InvalidInput(
+                "Mask pattern cannot be empty".to_string(),
+            ));
+        }
+
+        let overlap = mask_len.saturating_sub(1);
+        let effective_block = block_size.max(mask_len);
+        let buf_len = effective_block + overlap;
+        let mut buf = vec![0u8; buf_len];
+        let mut pos = 0usize;
+        let mut eof = false;
+        let mut global_offset = 0usize;
+        let mut matches = Vec::new();
+
+        loop {
+            while pos < buf_len && !eof {
+                match reader.read(&mut buf[pos..buf_len]) {
+                    Ok(0) => eof = true,
+                    Ok(n) => pos += n,
+                    Err(e) => return Err(e.into()),
+                }
+            }
+
+            if pos == 0 {
+                break;
+            }
+
+            let search_limit = if eof {
+                pos
+            } else {
+                pos.saturating_sub(overlap)
+            };
+            let mut start = 0;
+
+            while start <= pos.saturating_sub(mask_len) {
+                if self.matches_mask(&buf[start..start + mask_len], mask) {
+                    let in_overlap = !eof && start >= search_limit;
+
+                    if !in_overlap {
+                        matches.push(SearchMatch {
+                            offset: global_offset + start,
+                            data: buf[start..start + mask_len].to_vec(),
+                        });
+
+                        if !self.config.find_all {
+                            return Ok(matches);
+                        }
+                    }
+
+                    start = if self.config.no_overlap {
+                        start + mask_len
+                    } else {
+                        start + 1
+                    };
+                } else {
+                    start += 1;
+                }
+            }
+
+            if eof {
+                break;
+            }
+
+            let consumed = search_limit;
+            buf.copy_within(consumed..pos, 0);
+            global_offset += consumed;
+            pos -= consumed;
+        }
+
+        Ok(matches)
     }
 
     /// Performs parallel search on large data sets.
@@ -854,5 +1038,73 @@ mod tests {
             assert_eq!(seq.offset, par.offset, "Offsets should match");
             assert_eq!(seq.data, par.data, "Data should match");
         }
+    }
+
+    #[test]
+    fn test_stream_exact_finds_match() {
+        let config = make_config(SearchPattern::Exact(vec![0xCA, 0xFE, 0xBA, 0xBE]));
+        let cmd = SearchCommand::new(config);
+        let data: Vec<u8> = (0..10_000)
+            .map(|i| if i == 1234 { 0xCA } else { i as u8 })
+            .collect();
+        let mut patched = data.clone();
+        patched[1234..1238].copy_from_slice(&[0xCA, 0xFE, 0xBA, 0xBE]);
+
+        let matches = cmd.search_stream(&patched[..], 256).unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].offset, 1234);
+    }
+
+    #[test]
+    fn test_stream_exact_boundary_match() {
+        // Place a pattern so it straddles the block boundary.
+        let pattern = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let mut data = vec![0x00u8; 300];
+        data[250..254].copy_from_slice(&pattern); // spans block 256 boundary
+
+        let config = make_config(SearchPattern::Exact(pattern.clone()));
+        let cmd = SearchCommand::new(config);
+        let matches = cmd.search_stream(&data[..], 128).unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].offset, 250);
+    }
+
+    #[test]
+    fn test_stream_mask_boundary_match() {
+        let mask = vec![Some(0xDE), None, Some(0xBE), None];
+        let mut data = vec![0x00u8; 300];
+        data[250..254].copy_from_slice(&[0xDE, 0x11, 0xBE, 0x22]);
+
+        let config = make_config(SearchPattern::Mask(mask));
+        let cmd = SearchCommand::new(config);
+        let matches = cmd.search_stream(&data[..], 128).unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].offset, 250);
+    }
+
+    #[test]
+    fn test_stream_no_overlap() {
+        let mut config = make_config(SearchPattern::Exact(vec![0xAA, 0xBB]));
+        config.no_overlap = true;
+        let cmd = SearchCommand::new(config);
+        let data = [0xAA, 0xBB, 0xAA, 0xBB, 0xAA, 0xBB];
+
+        let matches = cmd.search_stream(&data[..], 3).unwrap();
+        assert_eq!(matches.len(), 3);
+        assert_eq!(matches[0].offset, 0);
+        assert_eq!(matches[1].offset, 2);
+        assert_eq!(matches[2].offset, 4);
+    }
+
+    #[test]
+    fn test_stream_find_first_only() {
+        let mut config = make_config(SearchPattern::Exact(vec![0xCC]));
+        config.find_all = false;
+        let cmd = SearchCommand::new(config);
+        let data = [0x00, 0xCC, 0x00, 0xCC];
+
+        let matches = cmd.search_stream(&data[..], 2).unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].offset, 1);
     }
 }

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -10,7 +10,10 @@
 /// src/commands/search.rs
 use super::Command;
 use crate::error::{BinfiddleError, Result};
-use crate::utils::display::{format_match, format_match_with_context, format_match_colored, format_match_with_context_colored};
+use crate::utils::display::{
+    format_match, format_match_colored, format_match_with_context,
+    format_match_with_context_colored,
+};
 use crate::utils::parsing::SearchPattern;
 use crate::{BinaryData, ColorMode};
 
@@ -289,7 +292,8 @@ impl SearchCommand {
 
                             // Only include if this match starts within our primary chunk region
                             // (not in the overlap region that belongs to the next chunk)
-                            let primary_end = (*chunk_start + PARALLEL_CHUNK_SIZE).min(haystack.len());
+                            let primary_end =
+                                (*chunk_start + PARALLEL_CHUNK_SIZE).min(haystack.len());
                             if absolute_offset < primary_end || *chunk_end == haystack.len() {
                                 chunk_matches.push(SearchMatch {
                                     offset: absolute_offset,
@@ -335,7 +339,11 @@ impl SearchCommand {
     }
 
     /// Parallel mask-based search with wildcard support.
-    fn search_mask_parallel(&self, haystack: &[u8], mask: &[Option<u8>]) -> Result<Vec<SearchMatch>> {
+    fn search_mask_parallel(
+        &self,
+        haystack: &[u8],
+        mask: &[Option<u8>],
+    ) -> Result<Vec<SearchMatch>> {
         if mask.is_empty() {
             return Err(BinfiddleError::InvalidInput(
                 "Mask pattern cannot be empty".to_string(),
@@ -655,9 +663,12 @@ mod tests {
 
         let matches = cmd.search(&data).unwrap();
         let output = cmd.format_results(&data, &matches).unwrap();
-        
+
         // Should contain ANSI escape codes when color is Always
-        assert!(output.contains("\x1b["), "Colored output should contain ANSI codes");
+        assert!(
+            output.contains("\x1b["),
+            "Colored output should contain ANSI codes"
+        );
         // Should still contain the actual data
         assert!(output.contains("be ef"), "Output should contain match data");
     }
@@ -672,9 +683,12 @@ mod tests {
 
         let matches = cmd.search(&data).unwrap();
         let output = cmd.format_results(&data, &matches).unwrap();
-        
+
         // Should contain ANSI escape codes
-        assert!(output.contains("\x1b["), "Colored context output should contain ANSI codes");
+        assert!(
+            output.contains("\x1b["),
+            "Colored context output should contain ANSI codes"
+        );
         // Should contain context labels
         assert!(output.contains("Before:"), "Should show before context");
         assert!(output.contains("Match:"), "Should show match");
@@ -690,9 +704,12 @@ mod tests {
 
         let matches = cmd.search(&data).unwrap();
         let output = cmd.format_results(&data, &matches).unwrap();
-        
+
         // Should NOT contain ANSI escape codes when color is Never
-        assert!(!output.contains("\x1b["), "No-color output should not contain ANSI codes");
+        assert!(
+            !output.contains("\x1b["),
+            "No-color output should not contain ANSI codes"
+        );
         // Should still contain the actual data
         assert!(output.contains("be ef"), "Output should contain match data");
     }
@@ -716,7 +733,7 @@ mod tests {
     fn test_parallel_exact_search_large_data() {
         // Create data larger than PARALLEL_THRESHOLD
         let mut data = vec![0x00u8; 2 * 1024 * 1024]; // 2MB
-        // Insert pattern at known locations
+                                                      // Insert pattern at known locations
         let pattern = [0xDE, 0xAD, 0xBE, 0xEF];
         for offset in [0, 100_000, 500_000, 1_000_000, 1_500_000, 2_097_148] {
             if offset + pattern.len() <= data.len() {
@@ -741,7 +758,7 @@ mod tests {
     fn test_parallel_mask_search_large_data() {
         // Create data larger than PARALLEL_THRESHOLD
         let mut data = vec![0x00u8; 2 * 1024 * 1024]; // 2MB
-        // Insert pattern at known locations
+                                                      // Insert pattern at known locations
         let pattern = [0xDE, 0xAD, 0xBE, 0xEF];
         for offset in [0, 256_000, 512_000, 1_024_000] {
             if offset + pattern.len() <= data.len() {
@@ -768,7 +785,7 @@ mod tests {
         // PARALLEL_CHUNK_SIZE is 256KB, so put pattern at boundary
         let chunk_boundary = 256 * 1024;
         let mut data = vec![0x00u8; 2 * 1024 * 1024]; // 2MB
-        
+
         // Pattern spanning the chunk boundary
         let pattern = [0xDE, 0xAD, 0xBE, 0xEF];
         let boundary_offset = chunk_boundary - 2; // Pattern starts 2 bytes before boundary
@@ -786,7 +803,7 @@ mod tests {
     fn test_parallel_no_overlap() {
         // Test no_overlap with parallel search
         let mut data = vec![0x00u8; 2 * 1024 * 1024]; // 2MB
-        // Create overlapping patterns: 00 00 00 00 at multiple locations
+                                                      // Create overlapping patterns: 00 00 00 00 at multiple locations
         let overlapping_start = 1_000_000;
         for i in 0..8 {
             data[overlapping_start + i] = 0x00;
@@ -797,12 +814,12 @@ mod tests {
         let cmd = SearchCommand::new(config);
 
         let matches = cmd.search_parallel(&data).unwrap();
-        
+
         // With no_overlap, consecutive 00 00 patterns should not overlap
         // Check that matches don't overlap
         for i in 1..matches.len() {
             assert!(
-                matches[i].offset >= matches[i-1].offset + matches[i-1].data.len(),
+                matches[i].offset >= matches[i - 1].offset + matches[i - 1].data.len(),
                 "Matches should not overlap"
             );
         }
@@ -813,7 +830,7 @@ mod tests {
         // Verify parallel and sequential produce same results
         let mut data = vec![0x00u8; 2 * 1024 * 1024]; // 2MB
         let pattern = [0xCA, 0xFE, 0xBA, 0xBE];
-        
+
         // Insert patterns at various locations
         for i in 0..100 {
             let offset = i * 20_000;
@@ -828,7 +845,11 @@ mod tests {
         let sequential = cmd.search(&data).unwrap();
         let parallel = cmd.search_parallel(&data).unwrap();
 
-        assert_eq!(sequential.len(), parallel.len(), "Match count should be equal");
+        assert_eq!(
+            sequential.len(),
+            parallel.len(),
+            "Match count should be equal"
+        );
         for (seq, par) in sequential.iter().zip(parallel.iter()) {
             assert_eq!(seq.offset, par.offset, "Offsets should match");
             assert_eq!(seq.data, par.data, "Data should match");

--- a/src/commands/struct_bits.rs
+++ b/src/commands/struct_bits.rs
@@ -1,0 +1,214 @@
+//! Bit-level addressing and reading for structural templates.
+//!
+//! Provides helpers to read arbitrary bit ranges from a byte slice using
+//! either MSB-first (big-endian) or LSB-first (little-endian) bit ordering.
+
+use crate::error::{BinfiddleError, Result};
+
+use super::struct_cmd::Endianness;
+
+/// A byte + bit address inside a binary stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BitAddress {
+    /// Byte offset from the start of the data.
+    pub byte: usize,
+    /// Bit index inside the byte, 0-7.
+    pub bit: u8,
+}
+
+impl BitAddress {
+    /// Creates a new bit address. The bit index is normalized to 0-7.
+    pub fn new(byte: usize, bit: u8) -> Self {
+        let total_bits = byte * 8 + bit as usize;
+        Self {
+            byte: total_bits / 8,
+            bit: (total_bits % 8) as u8,
+        }
+    }
+
+    /// Returns the absolute bit index (byte * 8 + bit).
+    pub fn flat(&self) -> usize {
+        self.byte * 8 + self.bit as usize
+    }
+
+    /// Adds a number of bits and returns the resulting address.
+    pub fn add_bits(&self, bits: usize) -> Self {
+        Self::new(self.byte, self.bit + bits as u8)
+    }
+}
+
+/// Reads `bit_count` bits starting at absolute bit index `bit_start`.
+///
+/// Bit ordering is determined by `endian`:
+/// - `Endianness::Big` treats the stream as MSB-first within each byte.
+///   The first bit read becomes the most significant bit of the result.
+/// - `Endianness::Little` treats the stream as LSB-first within each byte.
+///   The first bit read becomes the least significant bit of the result.
+///
+/// # Panics
+/// Panics if `bit_count` is greater than 64.
+pub fn read_bits(data: &[u8], bit_start: usize, bit_count: usize, endian: Endianness) -> u64 {
+    assert!(
+        bit_count <= 64,
+        "read_bits supports at most 64 bits, got {}",
+        bit_count
+    );
+    if bit_count == 0 {
+        return 0;
+    }
+
+    let mut result: u64 = 0;
+
+    match endian {
+        Endianness::Big => {
+            // MSB-first bit stream: bit 0 of the stream is the MSB of byte 0.
+            for i in 0..bit_count {
+                let bit_index = bit_start + i;
+                let byte_idx = bit_index / 8;
+                let bit_in_byte = 7 - (bit_index % 8);
+                if byte_idx >= data.len() {
+                    break;
+                }
+                let bit = ((data[byte_idx] >> bit_in_byte) & 1) as u64;
+                result = (result << 1) | bit;
+            }
+        }
+        Endianness::Little => {
+            // LSB-first bit stream: bit 0 of the stream is the LSB of byte 0.
+            for i in 0..bit_count {
+                let bit_index = bit_start + i;
+                let byte_idx = bit_index / 8;
+                let bit_in_byte = bit_index % 8;
+                if byte_idx >= data.len() {
+                    break;
+                }
+                let bit = ((data[byte_idx] >> bit_in_byte) & 1) as u64;
+                result |= bit << i;
+            }
+        }
+    }
+
+    result
+}
+
+/// Sign-extends an unsigned value of `bit_width` bits to a signed `i64`.
+pub fn sign_extend(value: u64, bit_width: usize) -> Result<i64> {
+    if bit_width == 0 {
+        return Err(BinfiddleError::Parse(
+            "Cannot sign-extend a zero-bit value".to_string(),
+        ));
+    }
+    if bit_width >= 64 {
+        return Ok(value as i64);
+    }
+    let sign_bit = 1u64 << (bit_width - 1);
+    Ok(if value & sign_bit != 0 {
+        // Negative: set all bits above bit_width to 1.
+        let mask = !0u64 << bit_width;
+        (value | mask) as i64
+    } else {
+        value as i64
+    })
+}
+
+/// Computes the number of bytes spanned by a bit range.
+pub fn byte_span(bit_offset: u8, bit_size: u8) -> usize {
+    let start = bit_offset as usize;
+    let end = start + bit_size as usize;
+    end.div_ceil(8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bit_address_new_normalizes() {
+        let addr = BitAddress::new(0, 10);
+        assert_eq!(addr.byte, 1);
+        assert_eq!(addr.bit, 2);
+        assert_eq!(addr.flat(), 10);
+    }
+
+    #[test]
+    fn test_bit_address_add_bits() {
+        let addr = BitAddress::new(1, 3).add_bits(10);
+        assert_eq!(addr.byte, 2);
+        assert_eq!(addr.bit, 5);
+    }
+
+    #[test]
+    fn test_read_bits_big_endian_single_msb() {
+        // 0b1000_0000 => reading bit 0 (MSB) gives 1
+        let data = [0x80];
+        assert_eq!(read_bits(&data, 0, 1, Endianness::Big), 1);
+        // reading bit 1 gives 0
+        assert_eq!(read_bits(&data, 1, 1, Endianness::Big), 0);
+    }
+
+    #[test]
+    fn test_read_bits_little_endian_single_lsb() {
+        // 0b0000_0001 => reading bit 0 (LSB) gives 1
+        let data = [0x01];
+        assert_eq!(read_bits(&data, 0, 1, Endianness::Little), 1);
+        // reading bit 1 gives 0
+        assert_eq!(read_bits(&data, 1, 1, Endianness::Little), 0);
+    }
+
+    #[test]
+    fn test_read_bits_big_endian_nibble() {
+        // 0b1010_0000 => bits 0..4 MSB-first = 1010 = 10
+        let data = [0xA0];
+        assert_eq!(read_bits(&data, 0, 4, Endianness::Big), 0b1010);
+    }
+
+    #[test]
+    fn test_read_bits_little_endian_nibble() {
+        // 0x0A = 0b0000_1010
+        // LSB-first: bit0=0, bit1=1, bit2=0, bit3=1 -> result = 0b1010 = 10
+        let data = [0x0A];
+        assert_eq!(read_bits(&data, 0, 4, Endianness::Little), 10);
+    }
+
+    #[test]
+    fn test_read_bits_big_endian_across_bytes() {
+        // Bytes: 0x12 0x34
+        // Big-endian bit stream: 0001 0010 0011 0100
+        // Read 12 bits starting at bit 4:
+        // skip first 4 bits -> 0010 0011 0100 = 0x234
+        let data = [0x12, 0x34];
+        assert_eq!(read_bits(&data, 4, 12, Endianness::Big), 0x234);
+    }
+
+    #[test]
+    fn test_read_bits_little_endian_across_bytes() {
+        // Bytes: 0x12 0x34
+        // Read 12 bits starting at bit 4 (LSB-first):
+        // bit4..bit15 -> 1,0,0,0,0,0,1,0,1,1,0,0
+        // result = 1 + 64 + 256 + 512 = 833
+        let data = [0x12, 0x34];
+        assert_eq!(read_bits(&data, 4, 12, Endianness::Little), 833);
+    }
+
+    #[test]
+    fn test_sign_extend_positive() {
+        assert_eq!(sign_extend(0b0101, 4).unwrap(), 5);
+    }
+
+    #[test]
+    fn test_sign_extend_negative() {
+        // 4-bit -3 = 1101
+        assert_eq!(sign_extend(0b1101, 4).unwrap(), -3);
+        // 3-bit -1 = 111
+        assert_eq!(sign_extend(0b111, 3).unwrap(), -1);
+    }
+
+    #[test]
+    fn test_byte_span() {
+        assert_eq!(byte_span(0, 1), 1);
+        assert_eq!(byte_span(4, 4), 1);
+        assert_eq!(byte_span(4, 5), 2);
+        assert_eq!(byte_span(0, 8), 1);
+        assert_eq!(byte_span(0, 9), 2);
+    }
+}

--- a/src/commands/struct_cmd.rs
+++ b/src/commands/struct_cmd.rs
@@ -53,6 +53,7 @@ use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use super::struct_bits::{byte_span, read_bits, sign_extend, BitAddress};
 use super::struct_expr::{eval_to_bool, eval_to_i128, resolve_size_or_offset, EvalContext};
 
 /// Endianness for multi-byte field interpretation.
@@ -151,6 +152,17 @@ impl FieldType {
             FieldType::U32 | FieldType::I32 => Some(4),
             FieldType::U64 | FieldType::I64 => Some(8),
             _ => None, // Variable size types
+        }
+    }
+
+    /// Returns the maximum bit width this type can hold, if it supports bit-level parsing.
+    pub fn max_bit_width(&self) -> Option<u8> {
+        match self {
+            FieldType::U8 | FieldType::I8 => Some(8),
+            FieldType::U16 | FieldType::I16 => Some(16),
+            FieldType::U32 | FieldType::I32 => Some(32),
+            FieldType::U64 | FieldType::I64 => Some(64),
+            _ => None,
         }
     }
 }
@@ -332,9 +344,18 @@ pub struct FieldDefinition {
     #[serde(default, deserialize_with = "deserialize_value_or_expression")]
     pub offset: Option<ValueOrExpression>,
 
-    /// Size in bytes (optional for computed/array fields)
+    /// Size in bytes (optional for computed/array fields or when bit_size is used)
     #[serde(default, deserialize_with = "deserialize_optional_value_or_expression")]
     pub size: Option<ValueOrExpression>,
+
+    /// Bit offset inside the byte at `offset` (0-7). Optional; defaults to 0.
+    #[serde(default)]
+    pub bit_offset: Option<u8>,
+
+    /// Size in bits (1-64). When present, the field is read at bit precision
+    /// and `size` is ignored.
+    #[serde(default)]
+    pub bit_size: Option<u8>,
 
     /// Data type for interpretation
     #[serde(rename = "type", default)]
@@ -462,6 +483,50 @@ impl StructTemplate {
                     }
                 }
             }
+
+            // Validate bit-level constraints
+            if let Some(bit_offset) = field.bit_offset {
+                if bit_offset >= 8 {
+                    return Err(BinfiddleError::Parse(format!(
+                        "Field '{}' has invalid bit_offset {}; must be 0-7",
+                        field.name, bit_offset
+                    )));
+                }
+            }
+            if let Some(bit_size) = field.bit_size {
+                if bit_size == 0 || bit_size > 64 {
+                    return Err(BinfiddleError::Parse(format!(
+                        "Field '{}' has invalid bit_size {}; must be 1-64",
+                        field.name, bit_size
+                    )));
+                }
+                if let Some(max_bits) = field.field_type.max_bit_width() {
+                    if bit_size > max_bits {
+                        return Err(BinfiddleError::Parse(format!(
+                            "Field '{}' has type {:?} which supports at most {} bits, but bit_size is {}",
+                            field.name, field.field_type, max_bits, bit_size
+                        )));
+                    }
+                } else {
+                    return Err(BinfiddleError::Parse(format!(
+                        "Field '{}' has type {:?} which does not support bit-level parsing",
+                        field.name, field.field_type
+                    )));
+                }
+
+                if field.count.is_some() {
+                    return Err(BinfiddleError::Parse(format!(
+                        "Field '{}' cannot use bit_size with counted arrays",
+                        field.name
+                    )));
+                }
+                if field.field_type == FieldType::Computed {
+                    return Err(BinfiddleError::Parse(format!(
+                        "Field '{}' cannot use bit_size with computed type",
+                        field.name
+                    )));
+                }
+            }
         }
 
         Ok(())
@@ -473,10 +538,16 @@ impl StructTemplate {
 pub struct ParsedField {
     /// Field name
     pub name: String,
-    /// Offset in data
+    /// Offset in data (start byte)
     pub offset: usize,
-    /// Size in bytes
+    /// Size in bytes (total bytes spanned)
     pub size: usize,
+    /// Bit offset inside the start byte, if this is a bit-level field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bit_offset: Option<u8>,
+    /// Size in bits, if this is a bit-level field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bit_size: Option<u8>,
     /// Raw bytes
     #[serde(skip)]
     pub raw_bytes: Vec<u8>,
@@ -651,6 +722,8 @@ impl StructCommand {
                 name: field.name.clone(),
                 offset,
                 size: 0,
+                bit_offset: None,
+                bit_size: None,
                 raw_bytes: Vec::new(),
                 value: format!("{}", value),
                 numeric_value: Some(value),
@@ -661,32 +734,56 @@ impl StructCommand {
             return Ok(vec![parsed]);
         }
 
-        // Resolve size for normal fields
-        let size = match &field.size {
-            Some(expr) => expr.resolve(ctx)?,
-            None => {
-                return Err(BinfiddleError::Parse(format!(
-                    "Field '{}' is missing required 'size'",
-                    field.name
-                )))
+        // Determine if this is a bit-level field.
+        let bit_offset_val = field.bit_offset.unwrap_or(0);
+        let (value, numeric_value, raw_bytes, size, bit_size_opt) = if let Some(bit_size) =
+            field.bit_size
+        {
+            let bit_start = BitAddress::new(offset, bit_offset_val).flat();
+            let span = byte_span(bit_offset_val, bit_size);
+            if offset + span > data.len() {
+                return Err(BinfiddleError::InvalidRange(format!(
+                    "Field '{}' at bit offset {} with bit size {} exceeds data length {} bits",
+                    field.name,
+                    bit_start,
+                    bit_size,
+                    data.len() * 8
+                )));
             }
+            let raw = data[offset..offset + span].to_vec();
+            let bits_value = read_bits(data, bit_start, bit_size as usize, endian);
+            let (value, numeric) = self.interpret_bits(bits_value, &field.field_type, bit_size)?;
+            (value, numeric, raw, span, Some(bit_size))
+        } else {
+            // Resolve size for normal byte-aligned fields
+            let size = match &field.size {
+                Some(expr) => expr.resolve(ctx)?,
+                None => {
+                    return Err(BinfiddleError::Parse(format!(
+                        "Field '{}' is missing required 'size'",
+                        field.name
+                    )))
+                }
+            };
+
+            // Bounds check
+            if offset + size > data.len() {
+                return Err(BinfiddleError::InvalidRange(format!(
+                    "Field '{}' at offset 0x{:x} with size {} exceeds data length {}",
+                    field.name,
+                    offset,
+                    size,
+                    data.len()
+                )));
+            }
+
+            let raw_bytes = data[offset..offset + size].to_vec();
+
+            // Parse based on type
+            let (value, numeric_value) =
+                self.interpret_field(&raw_bytes, &field.field_type, endian)?;
+            (value, numeric_value, raw_bytes, size, None)
         };
-
-        // Bounds check
-        if offset + size > data.len() {
-            return Err(BinfiddleError::InvalidRange(format!(
-                "Field '{}' at offset 0x{:x} with size {} exceeds data length {}",
-                field.name,
-                offset,
-                size,
-                data.len()
-            )));
-        }
-
-        let raw_bytes = data[offset..offset + size].to_vec();
-
-        // Parse based on type
-        let (value, numeric_value) = self.interpret_field(&raw_bytes, &field.field_type, endian)?;
 
         // Check enum mapping
         let enum_name = if let (Some(ref enum_map), Some(num)) = (&field.r#enum, numeric_value) {
@@ -695,11 +792,15 @@ impl StructCommand {
             None
         };
 
-        // Check assertion
-        let assertion_passed = field.assert.as_ref().map(|expected| {
-            let expected_bytes = self.parse_assert_value(expected);
-            expected_bytes.as_ref() == Some(&raw_bytes)
-        });
+        // Check assertion (only for byte-aligned fields; raw bytes include extra bits for bit fields)
+        let assertion_passed = if bit_size_opt.is_some() {
+            None
+        } else {
+            field.assert.as_ref().map(|expected| {
+                let expected_bytes = self.parse_assert_value(expected);
+                expected_bytes.as_ref() == Some(&raw_bytes)
+            })
+        };
 
         // Format the display value
         let display_value = if let Some(ref enum_name) = enum_name {
@@ -712,6 +813,8 @@ impl StructCommand {
             name: field.name.clone(),
             offset,
             size,
+            bit_offset: field.bit_offset,
+            bit_size: bit_size_opt,
             raw_bytes,
             value: display_value,
             numeric_value,
@@ -724,8 +827,9 @@ impl StructCommand {
 
         // Extract bitfields if defined and we have a numeric value
         if let (Some(bitfields), Some(numeric)) = (&field.bitfields, numeric_value) {
+            let max_bit = bit_size_opt.unwrap_or((size * 8) as u8);
             let mut bitfield_fields =
-                self.parse_bitfields(&field.name, offset, size, numeric, bitfields);
+                self.parse_bitfields(&field.name, offset, size, max_bit, numeric, bitfields);
             result.append(&mut bitfield_fields);
         }
 
@@ -812,6 +916,8 @@ impl StructCommand {
                     name: field_name,
                     offset: element_offset,
                     size,
+                    bit_offset: None,
+                    bit_size: None,
                     raw_bytes,
                     value,
                     numeric_value,
@@ -830,12 +936,12 @@ impl StructCommand {
         &self,
         parent_name: &str,
         parent_offset: usize,
-        parent_size: usize,
+        _parent_size: usize,
+        max_bit: u8,
         value: i128,
         bitfields: &[BitfieldDefinition],
     ) -> Vec<ParsedField> {
         let mut result = Vec::new();
-        let max_bit = (parent_size * 8) as u8;
 
         for bf in bitfields {
             let (start, end) = bf.bits;
@@ -867,6 +973,8 @@ impl StructCommand {
                 name,
                 offset: parent_offset,
                 size: 0,
+                bit_offset: None,
+                bit_size: None,
                 raw_bytes: Vec::new(),
                 value: display,
                 numeric_value: numeric,
@@ -877,6 +985,28 @@ impl StructCommand {
         }
 
         result
+    }
+
+    /// Interprets a bit-level value according to field type.
+    fn interpret_bits(
+        &self,
+        value: u64,
+        field_type: &FieldType,
+        bit_width: u8,
+    ) -> Result<(String, Option<i128>)> {
+        match field_type {
+            FieldType::U8 | FieldType::U16 | FieldType::U32 | FieldType::U64 => {
+                Ok((format!("{}", value), Some(value as i128)))
+            }
+            FieldType::I8 | FieldType::I16 | FieldType::I32 | FieldType::I64 => {
+                let signed = sign_extend(value, bit_width as usize)?;
+                Ok((format!("{}", signed), Some(signed as i128)))
+            }
+            _ => Err(BinfiddleError::Parse(format!(
+                "Type {:?} does not support bit-level parsing",
+                field_type
+            ))),
+        }
     }
 
     /// Interprets raw bytes according to field type.
@@ -1015,8 +1145,32 @@ impl StructCommand {
             .max()
             .unwrap_or(4)
             .max(4);
-        let offset_width = 10; // "0x00000000"
-        let size_width = 4;
+        let offset_width = parsed
+            .fields
+            .iter()
+            .map(|f| {
+                if f.bit_size.is_some() {
+                    "0x00000000.0".len()
+                } else {
+                    "0x00000000".len()
+                }
+            })
+            .max()
+            .unwrap_or(10)
+            .max(10);
+        let size_width = parsed
+            .fields
+            .iter()
+            .map(|f| {
+                if let Some(bit_size) = f.bit_size {
+                    format!("{}b", bit_size).len()
+                } else {
+                    format!("{}", f.size).len()
+                }
+            })
+            .max()
+            .unwrap_or(4)
+            .max(4);
         let value_width = parsed
             .fields
             .iter()
@@ -1057,14 +1211,27 @@ impl StructCommand {
                 None => "",
             };
 
+            let (offset_str, size_str) = if let Some(bit_size) = field.bit_size {
+                (
+                    format!("0x{:08x}.{} ", field.offset, field.bit_offset.unwrap_or(0)),
+                    format!("{}b", bit_size),
+                )
+            } else {
+                (
+                    format!("0x{:08x}  ", field.offset),
+                    format!("{}", field.size),
+                )
+            };
+
             output.push_str(&format!(
-                "{:<name_width$}  0x{:08x}  {:>size_width$}  {:<value_width$}  {}\n",
+                "{:<name_width$}  {:>offset_width$}  {:>size_width$}  {:<value_width$}  {}\n",
                 field.name,
-                field.offset,
-                field.size,
+                offset_str,
+                size_str,
                 field.value,
                 status,
                 name_width = name_width,
+                offset_width = offset_width,
                 size_width = size_width,
                 value_width = value_width
             ));
@@ -1131,22 +1298,33 @@ impl StructCommand {
         for field in &template.fields {
             let type_str = format!("{:?}", field.field_type);
             let desc = field.description.as_deref().unwrap_or("-");
-            let offset_str = field
-                .offset
-                .as_ref()
-                .map(|v| match v {
-                    ValueOrExpression::Number(n) => format!("0x{:08x}", n),
-                    ValueOrExpression::Expression(s) => s.clone(),
-                })
-                .unwrap_or_else(|| "auto".to_string());
-            let size_str = field
-                .size
-                .as_ref()
-                .map(|v| match v {
-                    ValueOrExpression::Number(n) => format!("{}", n),
-                    ValueOrExpression::Expression(s) => s.clone(),
-                })
-                .unwrap_or_else(|| "-".to_string());
+            let offset_str = {
+                let base = field
+                    .offset
+                    .as_ref()
+                    .map(|v| match v {
+                        ValueOrExpression::Number(n) => format!("0x{:08x}", n),
+                        ValueOrExpression::Expression(s) => s.clone(),
+                    })
+                    .unwrap_or_else(|| "auto".to_string());
+                if let Some(bit_offset) = field.bit_offset {
+                    format!("{}.{} ", base, bit_offset)
+                } else {
+                    base
+                }
+            };
+            let size_str = if let Some(bit_size) = field.bit_size {
+                format!("{}b", bit_size)
+            } else {
+                field
+                    .size
+                    .as_ref()
+                    .map(|v| match v {
+                        ValueOrExpression::Number(n) => format!("{}", n),
+                        ValueOrExpression::Expression(s) => s.clone(),
+                    })
+                    .unwrap_or_else(|| "-".to_string())
+            };
             output.push_str(&format!(
                 "{:<name_width$}  {:>10}  {:>4}  {:<type_width$}  {}\n",
                 field.name,
@@ -1941,5 +2119,195 @@ fields:
 
         assert_eq!(result.fields[1].offset, 2);
         assert_eq!(result.fields[1].numeric_value, Some(0xAB));
+    }
+
+    #[test]
+    fn test_bit_level_field_big_endian() {
+        let yaml = r#"
+name: Bit-level BE Test
+endian: big
+fields:
+  - name: nibble
+    offset: 0
+    bit_offset: 0
+    bit_size: 4
+    type: u8
+"#;
+        let template = StructTemplate::from_yaml(yaml).unwrap();
+        let data = vec![0xA0u8];
+
+        let cmd = StructCommand::new(StructConfig::default());
+        let result = cmd.parse(&data, &template).unwrap();
+
+        assert_eq!(result.fields.len(), 1);
+        assert_eq!(result.fields[0].name, "nibble");
+        assert_eq!(result.fields[0].numeric_value, Some(0xA));
+        assert_eq!(result.fields[0].bit_size, Some(4));
+        assert_eq!(result.fields[0].bit_offset, Some(0));
+    }
+
+    #[test]
+    fn test_bit_level_field_little_endian() {
+        let yaml = r#"
+name: Bit-level LE Test
+endian: little
+fields:
+  - name: nibble
+    offset: 0
+    bit_offset: 0
+    bit_size: 4
+    type: u8
+"#;
+        let template = StructTemplate::from_yaml(yaml).unwrap();
+        let data = vec![0x0Au8];
+
+        let cmd = StructCommand::new(StructConfig::default());
+        let result = cmd.parse(&data, &template).unwrap();
+
+        assert_eq!(result.fields[0].numeric_value, Some(0xA));
+    }
+
+    #[test]
+    fn test_bit_level_field_across_bytes() {
+        let yaml = r#"
+name: Bit-level Across Bytes Test
+endian: big
+fields:
+  - name: twelve_bits
+    offset: 0
+    bit_offset: 4
+    bit_size: 12
+    type: u16
+"#;
+        let template = StructTemplate::from_yaml(yaml).unwrap();
+        // Bytes: 0x12 0x34
+        // Big-endian bit stream starting at bit 4:
+        // 0001 0010 0011 0100
+        // skip first 4 bits -> 0010 0011 0100 = 0x234
+        let data = vec![0x12u8, 0x34u8];
+
+        let cmd = StructCommand::new(StructConfig::default());
+        let result = cmd.parse(&data, &template).unwrap();
+
+        assert_eq!(result.fields[0].numeric_value, Some(0x234));
+        assert_eq!(result.fields[0].size, 2);
+    }
+
+    #[test]
+    fn test_bit_level_signed_field() {
+        let yaml = r#"
+name: Bit-level Signed Test
+endian: big
+fields:
+  - name: signed_nibble
+    offset: 0
+    bit_offset: 0
+    bit_size: 4
+    type: i8
+"#;
+        let template = StructTemplate::from_yaml(yaml).unwrap();
+        // 0x80 => top 4 bits are 1000b = -8 in 4-bit two's complement
+        let data = vec![0x80u8];
+
+        let cmd = StructCommand::new(StructConfig::default());
+        let result = cmd.parse(&data, &template).unwrap();
+
+        assert_eq!(result.fields[0].numeric_value, Some(-8));
+    }
+
+    #[test]
+    fn test_bit_level_with_bitfields() {
+        let yaml = r#"
+name: Bit-level With Bitfields Test
+endian: big
+fields:
+  - name: packed
+    offset: 0
+    bit_size: 8
+    type: u8
+    bitfields:
+      - name: low
+        bits: 0..3
+        type: u8
+      - name: high
+        bits: 3..7
+        type: u8
+"#;
+        let template = StructTemplate::from_yaml(yaml).unwrap();
+        // 0xA7 = 1010 0111
+        // bits 0..3 = 0111 = 7
+        // bits 3..7 = 10100 = 20
+        let data = vec![0xA7u8];
+
+        let cmd = StructCommand::new(StructConfig::default());
+        let result = cmd.parse(&data, &template).unwrap();
+
+        assert_eq!(result.fields[0].numeric_value, Some(0xA7));
+        assert_eq!(result.fields[1].name, "packed.low");
+        assert_eq!(result.fields[1].numeric_value, Some(7));
+        assert_eq!(result.fields[2].name, "packed.high");
+        assert_eq!(result.fields[2].numeric_value, Some(20));
+    }
+
+    #[test]
+    fn test_bit_level_validation_rejects_bad_bit_offset() {
+        let yaml = r#"
+name: Bad Bit Offset Test
+fields:
+  - name: bad
+    offset: 0
+    bit_offset: 8
+    bit_size: 1
+    type: u8
+"#;
+        assert!(StructTemplate::from_yaml(yaml).unwrap().validate().is_err());
+    }
+
+    #[test]
+    fn test_bit_level_validation_rejects_zero_bit_size() {
+        let yaml = r#"
+name: Bad Bit Size Test
+fields:
+  - name: bad
+    offset: 0
+    bit_size: 0
+    type: u8
+"#;
+        assert!(StructTemplate::from_yaml(yaml).unwrap().validate().is_err());
+    }
+
+    #[test]
+    fn test_bit_level_validation_rejects_too_large_bit_size_for_type() {
+        let yaml = r#"
+name: Too Large Bit Size Test
+fields:
+  - name: bad
+    offset: 0
+    bit_size: 9
+    type: u8
+"#;
+        assert!(StructTemplate::from_yaml(yaml).unwrap().validate().is_err());
+    }
+
+    #[test]
+    fn test_bit_level_backwards_compatibility() {
+        // Existing byte-aligned templates should still work unchanged.
+        let yaml = r#"
+name: Byte-aligned Test
+endian: little
+fields:
+  - name: byte_value
+    offset: 0
+    size: 1
+    type: u8
+"#;
+        let template = StructTemplate::from_yaml(yaml).unwrap();
+        let data = vec![0x42u8];
+
+        let cmd = StructCommand::new(StructConfig::default());
+        let result = cmd.parse(&data, &template).unwrap();
+
+        assert_eq!(result.fields[0].numeric_value, Some(0x42));
+        assert_eq!(result.fields[0].bit_size, None);
     }
 }

--- a/src/commands/struct_cmd.rs
+++ b/src/commands/struct_cmd.rs
@@ -53,6 +53,8 @@ use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use super::struct_expr::{eval_to_bool, eval_to_i128, resolve_size_or_offset, EvalContext};
+
 /// Endianness for multi-byte field interpretation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -64,9 +66,11 @@ pub enum Endianness {
     Big,
 }
 
-impl Endianness {
+impl std::str::FromStr for Endianness {
+    type Err = BinfiddleError;
+
     /// Parses an endianness string.
-    pub fn from_str(s: &str) -> Result<Self> {
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "little" | "le" | "little-endian" | "littleendian" => Ok(Endianness::Little),
             "big" | "be" | "big-endian" | "bigendian" => Ok(Endianness::Big),
@@ -90,9 +94,11 @@ pub enum StructOutputFormat {
     Yaml,
 }
 
-impl StructOutputFormat {
+impl std::str::FromStr for StructOutputFormat {
+    type Err = BinfiddleError;
+
     /// Parses an output format string.
-    pub fn from_str(s: &str) -> Result<Self> {
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "human" | "table" | "text" => Ok(StructOutputFormat::Human),
             "json" => Ok(StructOutputFormat::Json),
@@ -106,7 +112,7 @@ impl StructOutputFormat {
 }
 
 /// Field data type for template fields.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FieldType {
     /// Unsigned 8-bit integer
@@ -130,13 +136,10 @@ pub enum FieldType {
     /// ASCII/UTF-8 string (null-terminated or fixed length)
     String,
     /// Raw byte array
+    #[default]
     Bytes,
-}
-
-impl Default for FieldType {
-    fn default() -> Self {
-        FieldType::Bytes
-    }
+    /// Computed value from an expression
+    Computed,
 }
 
 impl FieldType {
@@ -150,9 +153,12 @@ impl FieldType {
             _ => None, // Variable size types
         }
     }
+}
 
-    /// Parses a field type from string (for manual parsing if needed).
-    pub fn from_str(s: &str) -> Result<Self> {
+impl std::str::FromStr for FieldType {
+    type Err = BinfiddleError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "u8" | "uint8" | "byte" => Ok(FieldType::U8),
             "u16" | "uint16" | "word" | "ushort" => Ok(FieldType::U16),
@@ -165,13 +171,155 @@ impl FieldType {
             "hex_string" | "hexstring" | "hex" => Ok(FieldType::HexString),
             "string" | "str" | "ascii" | "utf8" => Ok(FieldType::String),
             "bytes" | "raw" | "data" => Ok(FieldType::Bytes),
+            "computed" | "calc" => Ok(FieldType::Computed),
             _ => Err(BinfiddleError::Parse(format!(
                 "Invalid field type '{}': expected u8, u16, u32, u64, i8, i16, i32, i64, \
-                 hex_string, string, or bytes",
+                 hex_string, string, bytes, or computed",
                 s
             ))),
         }
     }
+}
+
+/// A literal value or an expression string.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ValueOrExpression {
+    /// A fixed numeric value.
+    Number(usize),
+    /// An expression such as `$@prev_end + 4` or `$filename_length`.
+    Expression(String),
+}
+
+impl ValueOrExpression {
+    /// Returns the expression string if this is an expression.
+    pub fn as_expr(&self) -> Option<&str> {
+        match self {
+            ValueOrExpression::Expression(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Resolves to a usize using the given evaluation context.
+    pub fn resolve(&self, ctx: &EvalContext) -> Result<usize> {
+        match self {
+            ValueOrExpression::Number(n) => Ok(*n),
+            ValueOrExpression::Expression(s) => resolve_size_or_offset(s, ctx),
+        }
+    }
+}
+
+/// Definition of a bitfield within an integer field.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct BitfieldDefinition {
+    /// Name of the bitfield.
+    pub name: String,
+    /// Bit range, e.g. `0` or `2..5`.
+    #[serde(deserialize_with = "deserialize_bit_range")]
+    pub bits: (u8, u8),
+    /// Interpretation type: `bool`, `u8`, `u16`, `u32`, `u64`.
+    #[serde(rename = "type", default = "default_bitfield_type")]
+    pub field_type: String,
+    /// Optional description.
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+fn default_bitfield_type() -> String {
+    "bool".to_string()
+}
+
+/// Deserialize a bit range from either a single number or `start..end`.
+fn deserialize_bit_range<'de, D>(deserializer: D) -> std::result::Result<(u8, u8), D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum BitRangeValue {
+        Single(u8),
+        String(String),
+    }
+
+    match BitRangeValue::deserialize(deserializer)? {
+        BitRangeValue::Single(n) => Ok((n, n)),
+        BitRangeValue::String(s) => {
+            let s = s.trim();
+            if let Some((start, end)) = s.split_once("..") {
+                let start = start
+                    .trim()
+                    .parse::<u8>()
+                    .map_err(|e| D::Error::custom(format!("Invalid bit start: {}", e)))?;
+                let end = end
+                    .trim()
+                    .parse::<u8>()
+                    .map_err(|e| D::Error::custom(format!("Invalid bit end: {}", e)))?;
+                if start > end {
+                    return Err(D::Error::custom("Bit range start must be <= end"));
+                }
+                Ok((start, end))
+            } else {
+                let n = s
+                    .parse::<u8>()
+                    .map_err(|e| D::Error::custom(format!("Invalid bit index: {}", e)))?;
+                Ok((n, n))
+            }
+        }
+    }
+}
+
+/// Custom deserializer for `ValueOrExpression`.
+fn deserialize_value_or_expression<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<ValueOrExpression>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum RawValue {
+        Number(usize),
+        String(String),
+    }
+
+    match Option::<RawValue>::deserialize(deserializer)? {
+        None => Ok(None),
+        Some(RawValue::Number(n)) => Ok(Some(ValueOrExpression::Number(n))),
+        Some(RawValue::String(s)) => {
+            let s = s.trim();
+            if s.is_empty() {
+                return Err(D::Error::custom("Empty offset/size expression"));
+            }
+            if s.starts_with('$') {
+                Ok(Some(ValueOrExpression::Expression(s.to_string())))
+            } else {
+                // Try to parse as hex/decimal literal
+                let n = if s.starts_with("0x") || s.starts_with("0X") {
+                    usize::from_str_radix(&s[2..], 16).map_err(|e| {
+                        D::Error::custom(format!("Invalid hex value '{}': {}", s, e))
+                    })?
+                } else {
+                    s.parse::<usize>()
+                        .map_err(|e| D::Error::custom(format!("Invalid number '{}': {}", s, e)))?
+                };
+                Ok(Some(ValueOrExpression::Number(n)))
+            }
+        }
+    }
+}
+
+/// Custom deserializer for an optional `ValueOrExpression`.
+fn deserialize_optional_value_or_expression<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<ValueOrExpression>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_value_or_expression(deserializer)
 }
 
 /// Represents a single field definition in a template.
@@ -181,11 +329,12 @@ pub struct FieldDefinition {
     pub name: String,
 
     /// Byte offset from start of structure
-    #[serde(deserialize_with = "deserialize_offset")]
-    pub offset: usize,
+    #[serde(default, deserialize_with = "deserialize_value_or_expression")]
+    pub offset: Option<ValueOrExpression>,
 
-    /// Size in bytes
-    pub size: usize,
+    /// Size in bytes (optional for computed/array fields)
+    #[serde(default, deserialize_with = "deserialize_optional_value_or_expression")]
+    pub size: Option<ValueOrExpression>,
 
     /// Data type for interpretation
     #[serde(rename = "type", default)]
@@ -206,33 +355,26 @@ pub struct FieldDefinition {
     /// Optional display format override (hex, dec, bin, oct)
     #[serde(default)]
     pub display: Option<String>,
-}
 
-/// Custom deserializer for offset that handles hex strings.
-fn deserialize_offset<'de, D>(deserializer: D) -> std::result::Result<usize, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::de::Error;
+    /// Conditional expression; field is skipped if false.
+    #[serde(default)]
+    pub when: Option<String>,
 
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum OffsetValue {
-        Number(usize),
-        String(String),
-    }
+    /// For arrays: expression evaluating to element count.
+    #[serde(default)]
+    pub count: Option<String>,
 
-    match OffsetValue::deserialize(deserializer)? {
-        OffsetValue::Number(n) => Ok(n),
-        OffsetValue::String(s) => {
-            let s = s.trim();
-            if s.starts_with("0x") || s.starts_with("0X") {
-                usize::from_str_radix(&s[2..], 16).map_err(|e| D::Error::custom(e.to_string()))
-            } else {
-                s.parse::<usize>().map_err(|e| D::Error::custom(e.to_string()))
-            }
-        }
-    }
+    /// For arrays: template file to parse for each element.
+    #[serde(default)]
+    pub element_template: Option<String>,
+
+    /// For computed fields: expression yielding the value.
+    #[serde(default)]
+    pub value: Option<String>,
+
+    /// For integer fields: bitfield definitions.
+    #[serde(default)]
+    pub bitfields: Option<Vec<BitfieldDefinition>>,
 }
 
 /// Represents a complete structure template.
@@ -256,9 +398,8 @@ pub struct StructTemplate {
 impl StructTemplate {
     /// Loads a template from YAML string.
     pub fn from_yaml(yaml: &str) -> Result<Self> {
-        serde_yaml::from_str(yaml).map_err(|e| {
-            BinfiddleError::Parse(format!("Failed to parse template YAML: {}", e))
-        })
+        serde_yaml::from_str(yaml)
+            .map_err(|e| BinfiddleError::Parse(format!("Failed to parse template YAML: {}", e)))
     }
 
     /// Loads a template from a file path.
@@ -272,11 +413,21 @@ impl StructTemplate {
         Self::from_yaml(&content)
     }
 
-    /// Returns the total size covered by this template.
+    /// Returns the total size covered by this template using literal values only.
     pub fn total_size(&self) -> usize {
         self.fields
             .iter()
-            .map(|f| f.offset + f.size)
+            .filter_map(|f| {
+                let offset = match &f.offset {
+                    Some(ValueOrExpression::Number(n)) => *n,
+                    _ => return None,
+                };
+                let size = match &f.size {
+                    Some(ValueOrExpression::Number(n)) => *n,
+                    _ => return None,
+                };
+                Some(offset + size)
+            })
             .max()
             .unwrap_or(0)
     }
@@ -299,14 +450,16 @@ impl StructTemplate {
             }
         }
 
-        // Validate field type sizes
+        // Validate field type sizes for literal sizes
         for field in &self.fields {
             if let Some(expected) = field.field_type.expected_size() {
-                if field.size != expected {
-                    return Err(BinfiddleError::Parse(format!(
-                        "Field '{}' has type {:?} which requires {} bytes, but size is {}",
-                        field.name, field.field_type, expected, field.size
-                    )));
+                if let Some(ValueOrExpression::Number(size)) = &field.size {
+                    if *size != expected {
+                        return Err(BinfiddleError::Parse(format!(
+                            "Field '{}' has type {:?} which requires {} bytes, but size is {}",
+                            field.name, field.field_type, expected, size
+                        )));
+                    }
                 }
             }
         }
@@ -389,6 +542,17 @@ impl StructCommand {
     /// # Returns
     /// A ParsedStruct containing all field values.
     pub fn parse(&self, data: &[u8], template: &StructTemplate) -> Result<ParsedStruct> {
+        let ctx = EvalContext::new(data.len(), 0);
+        self.parse_with_context(data, template, ctx)
+    }
+
+    /// Parses binary data using an existing evaluation context.
+    fn parse_with_context(
+        &self,
+        data: &[u8],
+        template: &StructTemplate,
+        mut ctx: EvalContext,
+    ) -> Result<ParsedStruct> {
         // Validate template first
         template.validate()?;
 
@@ -403,16 +567,44 @@ impl StructCommand {
                 continue;
             }
 
-            let parsed = self.parse_field(data, field_def, template.endian)?;
-
-            // Check assertion
-            if let Some(passed) = parsed.assertion_passed {
-                if !passed {
-                    all_assertions_passed = false;
+            // Evaluate conditional
+            if let Some(when_expr) = &field_def.when {
+                if !eval_to_bool(when_expr, &ctx)? {
+                    continue;
                 }
             }
 
-            fields.push(parsed);
+            // Resolve offset: explicit or $@prev_end
+            let offset = match &field_def.offset {
+                Some(expr) => expr.resolve(&ctx)?,
+                None => ctx.prev_end(),
+            };
+            ctx.set_current_offset(offset);
+
+            // Parse the field (which may produce multiple parsed fields for arrays/bitfields)
+            let mut parsed_fields =
+                self.parse_field_at(data, field_def, offset, template.endian, &ctx)?;
+
+            // Update context with numeric values from all parsed fields and end offset
+            if let Some(main) = parsed_fields.first() {
+                ctx.set_prev_end(main.offset + main.size);
+            }
+            for parsed in &parsed_fields {
+                if let Some(numeric) = parsed.numeric_value {
+                    ctx.set_variable(parsed.name.clone(), numeric);
+                }
+            }
+
+            // Check assertions
+            for parsed in &parsed_fields {
+                if let Some(passed) = parsed.assertion_passed {
+                    if !passed {
+                        all_assertions_passed = false;
+                    }
+                }
+            }
+
+            fields.append(&mut parsed_fields);
         }
 
         Ok(ParsedStruct {
@@ -423,25 +615,75 @@ impl StructCommand {
         })
     }
 
-    /// Parses a single field from binary data.
-    fn parse_field(
+    /// Parses a field at the given offset, handling arrays, computed fields,
+    /// bitfields, and normal data fields.
+    fn parse_field_at(
         &self,
         data: &[u8],
         field: &FieldDefinition,
+        offset: usize,
         endian: Endianness,
-    ) -> Result<ParsedField> {
+        ctx: &EvalContext,
+    ) -> Result<Vec<ParsedField>> {
+        // Handle counted arrays
+        if let Some(count_expr) = &field.count {
+            let count = eval_to_i128(count_expr, ctx)?;
+            if count < 0 {
+                return Err(BinfiddleError::InvalidRange(format!(
+                    "Array count for field '{}' evaluated to negative value {}",
+                    field.name, count
+                )));
+            }
+            let count = count as usize;
+            return self.parse_array(data, field, offset, count, endian, ctx);
+        }
+
+        // Handle computed fields
+        if field.field_type == FieldType::Computed {
+            let value_expr = field.value.as_ref().ok_or_else(|| {
+                BinfiddleError::Parse(format!(
+                    "Computed field '{}' requires a 'value' expression",
+                    field.name
+                ))
+            })?;
+            let value = eval_to_i128(value_expr, ctx)?;
+            let parsed = ParsedField {
+                name: field.name.clone(),
+                offset,
+                size: 0,
+                raw_bytes: Vec::new(),
+                value: format!("{}", value),
+                numeric_value: Some(value),
+                enum_name: None,
+                assertion_passed: None,
+                description: field.description.clone(),
+            };
+            return Ok(vec![parsed]);
+        }
+
+        // Resolve size for normal fields
+        let size = match &field.size {
+            Some(expr) => expr.resolve(ctx)?,
+            None => {
+                return Err(BinfiddleError::Parse(format!(
+                    "Field '{}' is missing required 'size'",
+                    field.name
+                )))
+            }
+        };
+
         // Bounds check
-        if field.offset + field.size > data.len() {
+        if offset + size > data.len() {
             return Err(BinfiddleError::InvalidRange(format!(
                 "Field '{}' at offset 0x{:x} with size {} exceeds data length {}",
                 field.name,
-                field.offset,
-                field.size,
+                offset,
+                size,
                 data.len()
             )));
         }
 
-        let raw_bytes = data[field.offset..field.offset + field.size].to_vec();
+        let raw_bytes = data[offset..offset + size].to_vec();
 
         // Parse based on type
         let (value, numeric_value) = self.interpret_field(&raw_bytes, &field.field_type, endian)?;
@@ -466,17 +708,175 @@ impl StructCommand {
             value
         };
 
-        Ok(ParsedField {
+        let main_field = ParsedField {
             name: field.name.clone(),
-            offset: field.offset,
-            size: field.size,
+            offset,
+            size,
             raw_bytes,
             value: display_value,
             numeric_value,
             enum_name,
             assertion_passed,
             description: field.description.clone(),
-        })
+        };
+
+        let mut result = vec![main_field.clone()];
+
+        // Extract bitfields if defined and we have a numeric value
+        if let (Some(bitfields), Some(numeric)) = (&field.bitfields, numeric_value) {
+            let mut bitfield_fields =
+                self.parse_bitfields(&field.name, offset, size, numeric, bitfields);
+            result.append(&mut bitfield_fields);
+        }
+
+        Ok(result)
+    }
+
+    /// Parses a counted array of elements.
+    fn parse_array(
+        &self,
+        data: &[u8],
+        field: &FieldDefinition,
+        start_offset: usize,
+        count: usize,
+        endian: Endianness,
+        ctx: &EvalContext,
+    ) -> Result<Vec<ParsedField>> {
+        let mut result = Vec::new();
+
+        if let Some(template_name) = &field.element_template {
+            // Load external template for each element
+            let element_template = StructTemplate::from_file(template_name)?;
+            let element_size = element_template.total_size();
+            if element_size == 0 {
+                return Err(BinfiddleError::Parse(format!(
+                    "Array field '{}' uses element template '{}' with zero size",
+                    field.name, template_name
+                )));
+            }
+
+            for i in 0..count {
+                let element_offset = start_offset + i * element_size;
+                if element_offset + element_size > data.len() {
+                    return Err(BinfiddleError::InvalidRange(format!(
+                        "Array '{}' element {} at offset 0x{:x} with size {} exceeds data length {}",
+                        field.name,
+                        i,
+                        element_offset,
+                        element_size,
+                        data.len()
+                    )));
+                }
+
+                let element_ctx = ctx.child_with_base(element_offset);
+                let parsed_element =
+                    self.parse_with_context(data, &element_template, element_ctx)?;
+                for parsed_field in parsed_element.fields {
+                    let indexed_name = format!("{}[{}].{}", field.name, i, parsed_field.name);
+                    let mut indexed = parsed_field;
+                    indexed.name = indexed_name;
+                    result.push(indexed);
+                }
+            }
+        } else {
+            // Array of identical simple fields
+            let size = match &field.size {
+                Some(expr) => expr.resolve(ctx)?,
+                None => {
+                    return Err(BinfiddleError::Parse(format!(
+                        "Array field '{}' without element_template requires 'size'",
+                        field.name
+                    )))
+                }
+            };
+
+            for i in 0..count {
+                let element_offset = start_offset + i * size;
+                if element_offset + size > data.len() {
+                    return Err(BinfiddleError::InvalidRange(format!(
+                        "Array '{}' element {} at offset 0x{:x} with size {} exceeds data length {}",
+                        field.name,
+                        i,
+                        element_offset,
+                        size,
+                        data.len()
+                    )));
+                }
+
+                let raw_bytes = data[element_offset..element_offset + size].to_vec();
+                let (value, numeric_value) =
+                    self.interpret_field(&raw_bytes, &field.field_type, endian)?;
+
+                let field_name = format!("{}[{}]", field.name, i);
+                result.push(ParsedField {
+                    name: field_name,
+                    offset: element_offset,
+                    size,
+                    raw_bytes,
+                    value,
+                    numeric_value,
+                    enum_name: None,
+                    assertion_passed: None,
+                    description: field.description.clone(),
+                });
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Extracts bitfield values from an integer field.
+    fn parse_bitfields(
+        &self,
+        parent_name: &str,
+        parent_offset: usize,
+        parent_size: usize,
+        value: i128,
+        bitfields: &[BitfieldDefinition],
+    ) -> Vec<ParsedField> {
+        let mut result = Vec::new();
+        let max_bit = (parent_size * 8) as u8;
+
+        for bf in bitfields {
+            let (start, end) = bf.bits;
+            if end >= max_bit {
+                // Skip out-of-range bitfields silently; validation could be stricter
+                continue;
+            }
+            let width = (end - start + 1) as u32;
+            let mask = ((1i128 << width) - 1) << start;
+            let raw = ((value as u128 & mask as u128) >> start) as i128;
+
+            let (display, numeric) = match bf.field_type.to_lowercase().as_str() {
+                "bool" | "boolean" => (
+                    if raw != 0 {
+                        "true".to_string()
+                    } else {
+                        "false".to_string()
+                    },
+                    Some(raw),
+                ),
+                "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64" => {
+                    (format!("{}", raw), Some(raw))
+                }
+                _ => (format!("{}", raw), Some(raw)),
+            };
+
+            let name = format!("{}.{}", parent_name, bf.name);
+            result.push(ParsedField {
+                name,
+                offset: parent_offset,
+                size: 0,
+                raw_bytes: Vec::new(),
+                value: display,
+                numeric_value: numeric,
+                enum_name: None,
+                assertion_passed: None,
+                description: bf.description.clone(),
+            });
+        }
+
+        result
     }
 
     /// Interprets raw bytes according to field type.
@@ -559,6 +959,9 @@ impl StructCommand {
                     .join(" ");
                 Ok((hex_str, None))
             }
+            FieldType::Computed => Err(BinfiddleError::Parse(
+                "Computed fields should not be interpreted as raw bytes".to_string(),
+            )),
         }
     }
 
@@ -728,11 +1131,27 @@ impl StructCommand {
         for field in &template.fields {
             let type_str = format!("{:?}", field.field_type);
             let desc = field.description.as_deref().unwrap_or("-");
+            let offset_str = field
+                .offset
+                .as_ref()
+                .map(|v| match v {
+                    ValueOrExpression::Number(n) => format!("0x{:08x}", n),
+                    ValueOrExpression::Expression(s) => s.clone(),
+                })
+                .unwrap_or_else(|| "auto".to_string());
+            let size_str = field
+                .size
+                .as_ref()
+                .map(|v| match v {
+                    ValueOrExpression::Number(n) => format!("{}", n),
+                    ValueOrExpression::Expression(s) => s.clone(),
+                })
+                .unwrap_or_else(|| "-".to_string());
             output.push_str(&format!(
-                "{:<name_width$}  0x{:08x}  {:>4}  {:<type_width$}  {}\n",
+                "{:<name_width$}  {:>10}  {:>4}  {:<type_width$}  {}\n",
                 field.name,
-                field.offset,
-                field.size,
+                offset_str,
+                size_str,
                 type_str,
                 desc,
                 name_width = name_width,
@@ -756,6 +1175,20 @@ impl StructCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn literal_offset(offset: &Option<ValueOrExpression>) -> usize {
+        match offset {
+            Some(ValueOrExpression::Number(n)) => *n,
+            _ => panic!("Expected literal offset"),
+        }
+    }
+
+    fn literal_size(size: &Option<ValueOrExpression>) -> usize {
+        match size {
+            Some(ValueOrExpression::Number(n)) => *n,
+            _ => panic!("Expected literal size"),
+        }
+    }
 
     const ELF_TEMPLATE_YAML: &str = r#"
 name: ELF Header
@@ -821,8 +1254,8 @@ fields:
         assert_eq!(template.endian, Endianness::Little);
         assert_eq!(template.fields.len(), 4);
         assert_eq!(template.fields[0].name, "e_ident_magic");
-        assert_eq!(template.fields[0].offset, 0);
-        assert_eq!(template.fields[0].size, 4);
+        assert_eq!(literal_offset(&template.fields[0].offset), 0);
+        assert_eq!(literal_size(&template.fields[0].size), 4);
     }
 
     #[test]
@@ -836,7 +1269,7 @@ fields:
     type: u32
 "#;
         let template = StructTemplate::from_yaml(yaml).unwrap();
-        assert_eq!(template.fields[0].offset, 0x100);
+        assert_eq!(literal_offset(&template.fields[0].offset), 0x100);
     }
 
     #[test]
@@ -1116,43 +1549,49 @@ fields:
         let result = cmd.parse(&data, &template);
 
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("exceeds data length"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("exceeds data length"));
     }
 
     #[test]
     fn test_endianness_from_str() {
-        assert_eq!(Endianness::from_str("little").unwrap(), Endianness::Little);
-        assert_eq!(Endianness::from_str("big").unwrap(), Endianness::Big);
-        assert_eq!(Endianness::from_str("LE").unwrap(), Endianness::Little);
-        assert_eq!(Endianness::from_str("BE").unwrap(), Endianness::Big);
-        assert!(Endianness::from_str("invalid").is_err());
+        assert_eq!("little".parse::<Endianness>().unwrap(), Endianness::Little);
+        assert_eq!("big".parse::<Endianness>().unwrap(), Endianness::Big);
+        assert_eq!("LE".parse::<Endianness>().unwrap(), Endianness::Little);
+        assert_eq!("BE".parse::<Endianness>().unwrap(), Endianness::Big);
+        assert!("invalid".parse::<Endianness>().is_err());
     }
 
     #[test]
     fn test_output_format_from_str() {
         assert_eq!(
-            StructOutputFormat::from_str("human").unwrap(),
+            "human".parse::<StructOutputFormat>().unwrap(),
             StructOutputFormat::Human
         );
         assert_eq!(
-            StructOutputFormat::from_str("json").unwrap(),
+            "json".parse::<StructOutputFormat>().unwrap(),
             StructOutputFormat::Json
         );
         assert_eq!(
-            StructOutputFormat::from_str("yaml").unwrap(),
+            "yaml".parse::<StructOutputFormat>().unwrap(),
             StructOutputFormat::Yaml
         );
-        assert!(StructOutputFormat::from_str("invalid").is_err());
+        assert!("invalid".parse::<StructOutputFormat>().is_err());
     }
 
     #[test]
     fn test_field_type_from_str() {
-        assert_eq!(FieldType::from_str("u8").unwrap(), FieldType::U8);
-        assert_eq!(FieldType::from_str("u16").unwrap(), FieldType::U16);
-        assert_eq!(FieldType::from_str("uint32").unwrap(), FieldType::U32);
-        assert_eq!(FieldType::from_str("hex_string").unwrap(), FieldType::HexString);
-        assert_eq!(FieldType::from_str("string").unwrap(), FieldType::String);
-        assert!(FieldType::from_str("invalid").is_err());
+        assert_eq!("u8".parse::<FieldType>().unwrap(), FieldType::U8);
+        assert_eq!("u16".parse::<FieldType>().unwrap(), FieldType::U16);
+        assert_eq!("uint32".parse::<FieldType>().unwrap(), FieldType::U32);
+        assert_eq!(
+            "hex_string".parse::<FieldType>().unwrap(),
+            FieldType::HexString
+        );
+        assert_eq!("string".parse::<FieldType>().unwrap(), FieldType::String);
+        assert!("invalid".parse::<FieldType>().is_err());
     }
 
     #[test]
@@ -1166,7 +1605,7 @@ fields:
     fn test_template_get_field() {
         let template = StructTemplate::from_yaml(ELF_TEMPLATE_YAML).unwrap();
         let field = template.get_field("e_type").unwrap();
-        assert_eq!(field.offset, 0x10);
+        assert_eq!(literal_offset(&field.offset), 0x10);
         assert!(template.get_field("nonexistent").is_none());
     }
 
@@ -1290,5 +1729,217 @@ fields:
         assert_eq!(result.fields[5].numeric_value, Some(-50000));
         assert_eq!(result.fields[6].numeric_value, Some(1000000000000));
         assert_eq!(result.fields[7].numeric_value, Some(-500000000000));
+    }
+
+    #[test]
+    fn test_field_reference_in_size() {
+        let yaml = r#"
+name: Dynamic String
+endian: little
+fields:
+  - name: length
+    offset: 0
+    size: 2
+    type: u16
+  - name: data
+    offset: 2
+    size: $length
+    type: bytes
+"#;
+        let template = StructTemplate::from_yaml(yaml).unwrap();
+        let mut data = vec![0u8; 6];
+        data[0..2].copy_from_slice(&4u16.to_le_bytes());
+        data[2..6].copy_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+
+        let cmd = StructCommand::new(StructConfig::default());
+        let result = cmd.parse(&data, &template).unwrap();
+
+        assert_eq!(result.fields.len(), 2);
+        assert_eq!(result.fields[0].numeric_value, Some(4));
+        assert_eq!(result.fields[1].name, "data");
+        assert_eq!(result.fields[1].size, 4);
+        assert_eq!(result.fields[1].value, "de ad be ef");
+    }
+
+    #[test]
+    fn test_computed_field() {
+        let yaml = r#"
+name: Computed Test
+fields:
+  - name: a
+    offset: 0
+    size: 1
+    type: u8
+  - name: b
+    offset: 1
+    size: 1
+    type: u8
+  - name: sum
+    type: computed
+    value: $a + $b
+"#;
+        let template = StructTemplate::from_yaml(yaml).unwrap();
+        let data = vec![10u8, 32u8];
+
+        let cmd = StructCommand::new(StructConfig::default());
+        let result = cmd.parse(&data, &template).unwrap();
+
+        assert_eq!(result.fields.len(), 3);
+        assert_eq!(result.fields[2].name, "sum");
+        assert_eq!(result.fields[2].value, "42");
+        assert_eq!(result.fields[2].numeric_value, Some(42));
+    }
+
+    #[test]
+    fn test_conditional_field_with_bitfield_reference() {
+        let yaml = r#"
+name: Conditional Bitfield Test
+endian: big
+fields:
+  - name: flags
+    offset: 0
+    size: 1
+    type: u8
+    bitfields:
+      - name: urg
+        bits: 5
+        type: bool
+  - name: urgent_pointer
+    offset: 1
+    size: 1
+    type: u8
+    when: $flags.urg == 1
+"#;
+        let template = StructTemplate::from_yaml(yaml).unwrap();
+
+        // URG not set -> skip urgent_pointer
+        let data1 = vec![0x00u8, 0xFF];
+        let cmd = StructCommand::new(StructConfig::default());
+        let result1 = cmd.parse(&data1, &template).unwrap();
+        assert_eq!(result1.fields.len(), 2); // flags + flags.urg
+
+        // URG set -> parse urgent_pointer
+        let data2 = vec![0x20u8, 0xAB];
+        let result2 = cmd.parse(&data2, &template).unwrap();
+        assert_eq!(result2.fields.len(), 3);
+        assert_eq!(result2.fields[2].name, "urgent_pointer");
+        assert_eq!(result2.fields[2].numeric_value, Some(0xAB));
+    }
+
+    #[test]
+    fn test_conditional_field() {
+        let yaml = r#"
+name: Conditional Test
+fields:
+  - name: version
+    offset: 0
+    size: 1
+    type: u8
+  - name: extra
+    offset: 1
+    size: 1
+    type: u8
+    when: $version >= 2
+"#;
+        let template = StructTemplate::from_yaml(yaml).unwrap();
+
+        // version == 1: extra field should be skipped
+        let data1 = vec![1u8, 0xFF];
+        let cmd = StructCommand::new(StructConfig::default());
+        let result1 = cmd.parse(&data1, &template).unwrap();
+        assert_eq!(result1.fields.len(), 1);
+
+        // version == 2: extra field should be parsed
+        let data2 = vec![2u8, 0xAB];
+        let result2 = cmd.parse(&data2, &template).unwrap();
+        assert_eq!(result2.fields.len(), 2);
+        assert_eq!(result2.fields[1].numeric_value, Some(0xAB));
+    }
+
+    #[test]
+    fn test_bitfield_extraction() {
+        let yaml = r#"
+name: Bitfield Test
+endian: little
+fields:
+  - name: flags
+    offset: 0
+    size: 2
+    type: u16
+    bitfields:
+      - name: is_compressed
+        bits: 0
+        type: bool
+      - name: compression_level
+        bits: 2..5
+        type: u8
+"#;
+        let template = StructTemplate::from_yaml(yaml).unwrap();
+        // value = 0x0031 -> bit 0 = 1, bits 2-5 = 0b1100 (12)
+        let data = vec![0x31u8, 0x00u8];
+
+        let cmd = StructCommand::new(StructConfig::default());
+        let result = cmd.parse(&data, &template).unwrap();
+
+        assert_eq!(result.fields.len(), 3);
+        let is_compressed = &result.fields[1];
+        assert_eq!(is_compressed.name, "flags.is_compressed");
+        assert_eq!(is_compressed.value, "true");
+
+        let level = &result.fields[2];
+        assert_eq!(level.name, "flags.compression_level");
+        assert_eq!(level.numeric_value, Some(12));
+    }
+
+    #[test]
+    fn test_counted_array_of_simple_fields() {
+        let yaml = r#"
+name: Array Test
+endian: little
+fields:
+  - name: count
+    offset: 0
+    size: 1
+    type: u8
+  - name: values
+    offset: 1
+    size: 1
+    type: u8
+    count: $count
+"#;
+        let template = StructTemplate::from_yaml(yaml).unwrap();
+        let data = vec![3u8, 0xAA, 0xBB, 0xCC];
+
+        let cmd = StructCommand::new(StructConfig::default());
+        let result = cmd.parse(&data, &template).unwrap();
+
+        assert_eq!(result.fields.len(), 4); // count + 3 array elements
+        assert_eq!(result.fields[1].name, "values[0]");
+        assert_eq!(result.fields[1].numeric_value, Some(0xAA));
+        assert_eq!(result.fields[3].name, "values[2]");
+        assert_eq!(result.fields[3].numeric_value, Some(0xCC));
+    }
+
+    #[test]
+    fn test_auto_offset_with_prev_end() {
+        let yaml = r#"
+name: Auto Offset Test
+fields:
+  - name: first
+    offset: 0
+    size: 2
+    type: u16
+  - name: second
+    size: 1
+    type: u8
+"#;
+        let template = StructTemplate::from_yaml(yaml).unwrap();
+        let data = vec![0x00, 0x00, 0xAB];
+
+        let cmd = StructCommand::new(StructConfig::default());
+        let result = cmd.parse(&data, &template).unwrap();
+
+        assert_eq!(result.fields[1].offset, 2);
+        assert_eq!(result.fields[1].numeric_value, Some(0xAB));
     }
 }

--- a/src/commands/struct_expr.rs
+++ b/src/commands/struct_expr.rs
@@ -1,0 +1,699 @@
+//! Expression evaluation for structural templates.
+//!
+//! Provides a small, safe expression language used by the `struct` command
+//! to support dynamic offsets, sizes, conditional fields, computed values,
+//! and bitfield references.
+//!
+//! # Supported Syntax
+//!
+//! - Numbers: `42`, `0x2a`
+//! - Variables: `$fieldname`, `$@current`, `$@prev_end`, `$@file_size`, `$@base`
+//! - Bitfield references: `$flags.is_compressed`
+//! - Arithmetic: `+`, `-`, `*`, `/`, `%`, `**`
+//! - Comparisons: `==`, `!=`, `<`, `<=`, `>`, `>=`
+//! - Logic: `and`/`&&`, `or`/`||`, `not`
+//! - Parentheses for grouping
+
+use crate::error::{BinfiddleError, Result};
+use std::collections::HashMap;
+
+/// Context available during expression evaluation.
+#[derive(Debug, Clone, Default)]
+pub struct EvalContext {
+    /// Named field values (including bitfield values as `fieldname.bitfield`).
+    variables: HashMap<String, i128>,
+    /// Current parse offset.
+    current_offset: i128,
+    /// End offset of the previously parsed field.
+    prev_end: i128,
+    /// Total size of the input data.
+    file_size: i128,
+    /// Base offset of the current template (for nested templates).
+    base_offset: i128,
+}
+
+impl EvalContext {
+    /// Create a new context with magic variables initialized.
+    pub fn new(file_size: usize, base_offset: usize) -> Self {
+        Self {
+            variables: HashMap::new(),
+            current_offset: base_offset as i128,
+            prev_end: base_offset as i128,
+            file_size: file_size as i128,
+            base_offset: base_offset as i128,
+        }
+    }
+
+    /// Set the current parse offset.
+    pub fn set_current_offset(&mut self, offset: usize) {
+        self.current_offset = offset as i128;
+    }
+
+    /// Set the end offset of the previous parsed field.
+    pub fn set_prev_end(&mut self, end: usize) {
+        self.prev_end = end as i128;
+    }
+
+    /// Get the end offset of the previous parsed field.
+    pub fn prev_end(&self) -> usize {
+        self.prev_end as usize
+    }
+
+    /// Insert a named variable value.
+    pub fn set_variable(&mut self, name: impl Into<String>, value: i128) {
+        self.variables.insert(name.into(), value);
+    }
+
+    /// Create a child context for parsing at a new base offset, copying all variables.
+    pub fn child_with_base(&self, base_offset: usize) -> Self {
+        Self {
+            variables: self.variables.clone(),
+            current_offset: base_offset as i128,
+            prev_end: base_offset as i128,
+            file_size: self.file_size,
+            base_offset: base_offset as i128,
+        }
+    }
+
+    /// Get a variable value.
+    fn get(&self, name: &str) -> Option<i128> {
+        match name {
+            "@current" => Some(self.current_offset),
+            "@prev_end" => Some(self.prev_end),
+            "@file_size" => Some(self.file_size),
+            "@base" => Some(self.base_offset),
+            _ => self.variables.get(name).copied(),
+        }
+    }
+}
+
+/// Token produced by the expression tokenizer.
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    Number(i128),
+    Variable(String),
+    Plus,
+    Minus,
+    Star,
+    Slash,
+    Percent,
+    Power,
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    And,
+    Or,
+    Not,
+    LParen,
+    RParen,
+    Eof,
+}
+
+/// Tokenizes an expression string.
+fn tokenize(input: &str) -> Result<Vec<Token>> {
+    let mut tokens = Vec::new();
+    let chars: Vec<char> = input.chars().collect();
+    let mut i = 0;
+
+    while i < chars.len() {
+        let c = chars[i];
+
+        if c.is_whitespace() {
+            i += 1;
+            continue;
+        }
+
+        if c == '$' {
+            // Variable: $@name or $name or $name.subname
+            i += 1;
+            let mut name = String::new();
+            if i < chars.len() && chars[i] == '@' {
+                name.push('@');
+                i += 1;
+            }
+            let start = i;
+            while i < chars.len()
+                && (chars[i].is_alphanumeric() || chars[i] == '_' || chars[i] == '.')
+            {
+                i += 1;
+            }
+            name.push_str(&input[start..i]);
+            if name.is_empty() || name == "@" {
+                return Err(BinfiddleError::Parse(format!(
+                    "Empty variable reference in expression '{}'",
+                    input
+                )));
+            }
+            tokens.push(Token::Variable(name));
+            continue;
+        }
+
+        if c.is_ascii_digit() || (c == '0' && i + 1 < chars.len() && chars[i + 1] == 'x') {
+            let start = i;
+            if c == '0' && i + 1 < chars.len() && chars[i + 1] == 'x' {
+                i += 2;
+                while i < chars.len() && chars[i].is_ascii_hexdigit() {
+                    i += 1;
+                }
+                let num_str = &input[start + 2..i];
+                let value = i128::from_str_radix(num_str, 16).map_err(|e| {
+                    BinfiddleError::Parse(format!(
+                        "Invalid hex number '{}' in expression '{}': {}",
+                        num_str, input, e
+                    ))
+                })?;
+                tokens.push(Token::Number(value));
+            } else {
+                while i < chars.len() && chars[i].is_ascii_digit() {
+                    i += 1;
+                }
+                let num_str = &input[start..i];
+                let value = num_str.parse::<i128>().map_err(|e| {
+                    BinfiddleError::Parse(format!(
+                        "Invalid number '{}' in expression '{}': {}",
+                        num_str, input, e
+                    ))
+                })?;
+                tokens.push(Token::Number(value));
+            }
+            continue;
+        }
+
+        if c.is_alphabetic() {
+            let start = i;
+            while i < chars.len() && chars[i].is_alphabetic() {
+                i += 1;
+            }
+            let word = &input[start..i];
+            let token = match word.to_lowercase().as_str() {
+                "and" => Token::And,
+                "or" => Token::Or,
+                "not" => Token::Not,
+                _ => {
+                    return Err(BinfiddleError::Parse(format!(
+                        "Unknown keyword '{}' in expression '{}'",
+                        word, input
+                    )))
+                }
+            };
+            tokens.push(token);
+            continue;
+        }
+
+        let (token, advance) = match c {
+            '+' => (Token::Plus, 1),
+            '-' => (Token::Minus, 1),
+            '*' => {
+                if i + 1 < chars.len() && chars[i + 1] == '*' {
+                    (Token::Power, 2)
+                } else {
+                    (Token::Star, 1)
+                }
+            }
+            '/' => (Token::Slash, 1),
+            '%' => (Token::Percent, 1),
+            '(' => (Token::LParen, 1),
+            ')' => (Token::RParen, 1),
+            '<' => {
+                if i + 1 < chars.len() && chars[i + 1] == '=' {
+                    (Token::Le, 2)
+                } else {
+                    (Token::Lt, 1)
+                }
+            }
+            '>' => {
+                if i + 1 < chars.len() && chars[i + 1] == '=' {
+                    (Token::Ge, 2)
+                } else {
+                    (Token::Gt, 1)
+                }
+            }
+            '=' => {
+                if i + 1 < chars.len() && chars[i + 1] == '=' {
+                    (Token::Eq, 2)
+                } else {
+                    return Err(BinfiddleError::Parse(format!(
+                        "Unexpected '=' in expression '{}' (did you mean '=='?)",
+                        input
+                    )));
+                }
+            }
+            '!' => {
+                if i + 1 < chars.len() && chars[i + 1] == '=' {
+                    (Token::Ne, 2)
+                } else {
+                    return Err(BinfiddleError::Parse(format!(
+                        "Unexpected '!' in expression '{}' (did you mean '!='?)",
+                        input
+                    )));
+                }
+            }
+            '&' => {
+                if i + 1 < chars.len() && chars[i + 1] == '&' {
+                    (Token::And, 2)
+                } else {
+                    return Err(BinfiddleError::Parse(format!(
+                        "Unexpected '&' in expression '{}' (did you mean '&&'?)",
+                        input
+                    )));
+                }
+            }
+            '|' => {
+                if i + 1 < chars.len() && chars[i + 1] == '|' {
+                    (Token::Or, 2)
+                } else {
+                    return Err(BinfiddleError::Parse(format!(
+                        "Unexpected '|' in expression '{}' (did you mean '||'?)",
+                        input
+                    )));
+                }
+            }
+            _ => {
+                return Err(BinfiddleError::Parse(format!(
+                    "Unexpected character '{}' in expression '{}'",
+                    c, input
+                )))
+            }
+        };
+
+        tokens.push(token);
+        i += advance;
+    }
+
+    tokens.push(Token::Eof);
+    Ok(tokens)
+}
+
+/// Type alias for binary expression constructors.
+type BinExprCtor = fn(Box<Expr>, Box<Expr>) -> Expr;
+
+/// Parsed expression tree.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    Number(i128),
+    Variable(String),
+    Neg(Box<Expr>),
+    Not(Box<Expr>),
+    Add(Box<Expr>, Box<Expr>),
+    Sub(Box<Expr>, Box<Expr>),
+    Mul(Box<Expr>, Box<Expr>),
+    Div(Box<Expr>, Box<Expr>),
+    Mod(Box<Expr>, Box<Expr>),
+    Pow(Box<Expr>, Box<Expr>),
+    Eq(Box<Expr>, Box<Expr>),
+    Ne(Box<Expr>, Box<Expr>),
+    Lt(Box<Expr>, Box<Expr>),
+    Le(Box<Expr>, Box<Expr>),
+    Gt(Box<Expr>, Box<Expr>),
+    Ge(Box<Expr>, Box<Expr>),
+    And(Box<Expr>, Box<Expr>),
+    Or(Box<Expr>, Box<Expr>),
+}
+
+/// Recursive descent parser for expressions.
+struct Parser {
+    tokens: Vec<Token>,
+    pos: usize,
+}
+
+impl Parser {
+    fn new(tokens: Vec<Token>) -> Self {
+        Self { tokens, pos: 0 }
+    }
+
+    fn peek(&self) -> &Token {
+        self.tokens.get(self.pos).unwrap_or(&Token::Eof)
+    }
+
+    fn next(&mut self) -> Token {
+        let token = self.tokens.get(self.pos).cloned().unwrap_or(Token::Eof);
+        if self.pos < self.tokens.len() - 1 {
+            self.pos += 1;
+        }
+        token
+    }
+
+    fn expect(&mut self, expected: Token) -> Result<()> {
+        let token = self.next();
+        if std::mem::discriminant(&token) != std::mem::discriminant(&expected) {
+            return Err(BinfiddleError::Parse(format!(
+                "Expected {:?}, got {:?}",
+                expected, token
+            )));
+        }
+        Ok(())
+    }
+
+    fn parse(&mut self) -> Result<Expr> {
+        let expr = self.parse_or()?;
+        self.expect(Token::Eof)?;
+        Ok(expr)
+    }
+
+    fn parse_or(&mut self) -> Result<Expr> {
+        let mut left = self.parse_and()?;
+        while matches!(self.peek(), Token::Or) {
+            self.next();
+            let right = self.parse_and()?;
+            left = Expr::Or(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_and(&mut self) -> Result<Expr> {
+        let mut left = self.parse_not()?;
+        while matches!(self.peek(), Token::And) {
+            self.next();
+            let right = self.parse_not()?;
+            left = Expr::And(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_not(&mut self) -> Result<Expr> {
+        if matches!(self.peek(), Token::Not) {
+            self.next();
+            let expr = self.parse_not()?;
+            Ok(Expr::Not(Box::new(expr)))
+        } else {
+            self.parse_comparison()
+        }
+    }
+
+    fn parse_comparison(&mut self) -> Result<Expr> {
+        let left = self.parse_additive()?;
+        let op: Option<BinExprCtor> = match self.peek() {
+            Token::Eq => Some(Expr::Eq as BinExprCtor),
+            Token::Ne => Some(Expr::Ne as BinExprCtor),
+            Token::Lt => Some(Expr::Lt as BinExprCtor),
+            Token::Le => Some(Expr::Le as BinExprCtor),
+            Token::Gt => Some(Expr::Gt as BinExprCtor),
+            Token::Ge => Some(Expr::Ge as BinExprCtor),
+            _ => None,
+        };
+
+        if let Some(ctor) = op {
+            self.next();
+            let right = self.parse_additive()?;
+            Ok(ctor(Box::new(left), Box::new(right)))
+        } else {
+            Ok(left)
+        }
+    }
+
+    fn parse_additive(&mut self) -> Result<Expr> {
+        let mut left = self.parse_multiplicative()?;
+        loop {
+            match self.peek() {
+                Token::Plus => {
+                    self.next();
+                    let right = self.parse_multiplicative()?;
+                    left = Expr::Add(Box::new(left), Box::new(right));
+                }
+                Token::Minus => {
+                    self.next();
+                    let right = self.parse_multiplicative()?;
+                    left = Expr::Sub(Box::new(left), Box::new(right));
+                }
+                _ => break,
+            }
+        }
+        Ok(left)
+    }
+
+    fn parse_multiplicative(&mut self) -> Result<Expr> {
+        let mut left = self.parse_power()?;
+        loop {
+            match self.peek() {
+                Token::Star => {
+                    self.next();
+                    let right = self.parse_power()?;
+                    left = Expr::Mul(Box::new(left), Box::new(right));
+                }
+                Token::Slash => {
+                    self.next();
+                    let right = self.parse_power()?;
+                    left = Expr::Div(Box::new(left), Box::new(right));
+                }
+                Token::Percent => {
+                    self.next();
+                    let right = self.parse_power()?;
+                    left = Expr::Mod(Box::new(left), Box::new(right));
+                }
+                _ => break,
+            }
+        }
+        Ok(left)
+    }
+
+    fn parse_power(&mut self) -> Result<Expr> {
+        let base = self.parse_unary()?;
+        if matches!(self.peek(), Token::Power) {
+            self.next();
+            let exp = self.parse_unary()?;
+            Ok(Expr::Pow(Box::new(base), Box::new(exp)))
+        } else {
+            Ok(base)
+        }
+    }
+
+    fn parse_unary(&mut self) -> Result<Expr> {
+        match self.peek() {
+            Token::Minus => {
+                self.next();
+                let expr = self.parse_unary()?;
+                Ok(Expr::Neg(Box::new(expr)))
+            }
+            Token::Plus => {
+                self.next();
+                self.parse_unary()
+            }
+            _ => self.parse_primary(),
+        }
+    }
+
+    fn parse_primary(&mut self) -> Result<Expr> {
+        match self.next() {
+            Token::Number(n) => Ok(Expr::Number(n)),
+            Token::Variable(name) => Ok(Expr::Variable(name)),
+            Token::LParen => {
+                let expr = self.parse_or()?;
+                self.expect(Token::RParen)?;
+                Ok(expr)
+            }
+            token => Err(BinfiddleError::Parse(format!(
+                "Unexpected token {:?} in expression",
+                token
+            ))),
+        }
+    }
+}
+
+/// Parses an expression string into an AST.
+pub fn parse_expression(input: &str) -> Result<Expr> {
+    let tokens = tokenize(input)?;
+    let mut parser = Parser::new(tokens);
+    parser.parse()
+}
+
+/// Evaluates an expression to an integer value.
+pub fn evaluate(expr: &Expr, ctx: &EvalContext) -> Result<i128> {
+    match expr {
+        Expr::Number(n) => Ok(*n),
+        Expr::Variable(name) => ctx.get(name).ok_or_else(|| {
+            BinfiddleError::Parse(format!(
+                "Unknown variable '${}' in expression (available: current, prev_end, file_size, base, and parsed fields)",
+                name
+            ))
+        }),
+        Expr::Neg(e) => Ok(-evaluate(e, ctx)?),
+        Expr::Not(e) => {
+            let v = evaluate(e, ctx)?;
+            Ok(if v == 0 { 1 } else { 0 })
+        }
+        Expr::Add(a, b) => Ok(evaluate(a, ctx)? + evaluate(b, ctx)?),
+        Expr::Sub(a, b) => Ok(evaluate(a, ctx)? - evaluate(b, ctx)?),
+        Expr::Mul(a, b) => Ok(evaluate(a, ctx)? * evaluate(b, ctx)?),
+        Expr::Div(a, b) => {
+            let denom = evaluate(b, ctx)?;
+            if denom == 0 {
+                return Err(BinfiddleError::Parse(
+                    "Division by zero in expression".to_string(),
+                ));
+            }
+            Ok(evaluate(a, ctx)? / denom)
+        }
+        Expr::Mod(a, b) => {
+            let denom = evaluate(b, ctx)?;
+            if denom == 0 {
+                return Err(BinfiddleError::Parse(
+                    "Modulo by zero in expression".to_string(),
+                ));
+            }
+            Ok(evaluate(a, ctx)? % denom)
+        }
+        Expr::Pow(a, b) => {
+            let base = evaluate(a, ctx)?;
+            let exp = evaluate(b, ctx)?;
+            if exp < 0 {
+                return Err(BinfiddleError::Parse(
+                    "Negative exponent in expression".to_string(),
+                ));
+            }
+            Ok(base.pow(exp as u32))
+        }
+        Expr::Eq(a, b) => {
+            let left = evaluate(a, ctx)?;
+            let right = evaluate(b, ctx)?;
+            Ok(if left == right { 1 } else { 0 })
+        }
+        Expr::Ne(a, b) => {
+            let left = evaluate(a, ctx)?;
+            let right = evaluate(b, ctx)?;
+            Ok(if left != right { 1 } else { 0 })
+        }
+        Expr::Lt(a, b) => {
+            let left = evaluate(a, ctx)?;
+            let right = evaluate(b, ctx)?;
+            Ok(if left < right { 1 } else { 0 })
+        }
+        Expr::Le(a, b) => {
+            let left = evaluate(a, ctx)?;
+            let right = evaluate(b, ctx)?;
+            Ok(if left <= right { 1 } else { 0 })
+        }
+        Expr::Gt(a, b) => {
+            let left = evaluate(a, ctx)?;
+            let right = evaluate(b, ctx)?;
+            Ok(if left > right { 1 } else { 0 })
+        }
+        Expr::Ge(a, b) => {
+            let left = evaluate(a, ctx)?;
+            let right = evaluate(b, ctx)?;
+            Ok(if left >= right { 1 } else { 0 })
+        }
+        Expr::And(a, b) => {
+            let left = evaluate(a, ctx)?;
+            if left == 0 {
+                Ok(0)
+            } else {
+                let right = evaluate(b, ctx)?;
+                Ok(if right != 0 { 1 } else { 0 })
+            }
+        }
+        Expr::Or(a, b) => {
+            let left = evaluate(a, ctx)?;
+            if left != 0 {
+                Ok(1)
+            } else {
+                let right = evaluate(b, ctx)?;
+                Ok(if right != 0 { 1 } else { 0 })
+            }
+        }
+    }
+}
+
+/// Evaluates an expression string directly to an integer.
+pub fn eval_to_i128(input: &str, ctx: &EvalContext) -> Result<i128> {
+    let expr = parse_expression(input)?;
+    evaluate(&expr, ctx)
+}
+
+/// Evaluates an expression string as a boolean.
+pub fn eval_to_bool(input: &str, ctx: &EvalContext) -> Result<bool> {
+    Ok(eval_to_i128(input, ctx)? != 0)
+}
+
+/// Resolves a value-or-expression string to a non-negative size/offset.
+pub fn resolve_size_or_offset(input: &str, ctx: &EvalContext) -> Result<usize> {
+    let value = eval_to_i128(input, ctx)?;
+    if value < 0 {
+        return Err(BinfiddleError::InvalidRange(format!(
+            "Expression '{}' evaluated to negative value {}",
+            input, value
+        )));
+    }
+    value
+        .try_into()
+        .map_err(|_| BinfiddleError::InvalidRange(format!("Value {} exceeds usize range", value)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_literal_numbers() {
+        let ctx = EvalContext::new(100, 0);
+        assert_eq!(eval_to_i128("42", &ctx).unwrap(), 42);
+        assert_eq!(eval_to_i128("0x2a", &ctx).unwrap(), 42);
+    }
+
+    #[test]
+    fn test_arithmetic() {
+        let ctx = EvalContext::new(100, 0);
+        assert_eq!(eval_to_i128("2 + 3 * 4", &ctx).unwrap(), 14);
+        assert_eq!(eval_to_i128("(2 + 3) * 4", &ctx).unwrap(), 20);
+        assert_eq!(eval_to_i128("10 - 3", &ctx).unwrap(), 7);
+        assert_eq!(eval_to_i128("2 ** 8", &ctx).unwrap(), 256);
+        assert_eq!(eval_to_i128("17 % 5", &ctx).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_variables() {
+        let mut ctx = EvalContext::new(1000, 0);
+        ctx.set_variable("length", 10);
+        ctx.set_variable("offset", 0x100);
+        assert_eq!(eval_to_i128("$length + 5", &ctx).unwrap(), 15);
+        assert_eq!(eval_to_i128("$offset", &ctx).unwrap(), 256);
+        assert_eq!(eval_to_i128("$@file_size", &ctx).unwrap(), 1000);
+    }
+
+    #[test]
+    fn test_comparisons_and_logic() {
+        let mut ctx = EvalContext::new(100, 0);
+        ctx.set_variable("version", 2);
+        assert!(eval_to_bool("$version >= 2", &ctx).unwrap());
+        assert!(!eval_to_bool("$version == 1", &ctx).unwrap());
+        assert!(eval_to_bool("$version >= 2 and $version < 5", &ctx).unwrap());
+        assert!(eval_to_bool("$version == 1 or $version == 2", &ctx).unwrap());
+        assert!(eval_to_bool("not ($version == 1)", &ctx).unwrap());
+    }
+
+    #[test]
+    fn test_bitfield_variable() {
+        let mut ctx = EvalContext::new(100, 0);
+        ctx.set_variable("flags.is_compressed", 1);
+        assert!(eval_to_bool("$flags.is_compressed", &ctx).unwrap());
+    }
+
+    #[test]
+    fn test_magic_variables() {
+        let ctx = EvalContext::new(1000, 0x100);
+        assert_eq!(eval_to_i128("$@file_size", &ctx).unwrap(), 1000);
+        assert_eq!(eval_to_i128("$@base", &ctx).unwrap(), 0x100);
+    }
+
+    #[test]
+    fn test_error_unknown_variable() {
+        let ctx = EvalContext::new(100, 0);
+        assert!(eval_to_i128("$missing", &ctx).is_err());
+    }
+
+    #[test]
+    fn test_error_division_by_zero() {
+        let ctx = EvalContext::new(100, 0);
+        assert!(eval_to_i128("10 / 0", &ctx).is_err());
+    }
+
+    #[test]
+    fn test_resolve_size_or_offset() {
+        let mut ctx = EvalContext::new(100, 0);
+        ctx.set_variable("len", 10);
+        assert_eq!(resolve_size_or_offset("$len + 2", &ctx).unwrap(), 12);
+        assert!(resolve_size_or_offset("-1", &ctx).is_err());
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,13 @@ pub enum BinfiddleError {
 
     #[error("Operation not supported: {0}")]
     UnsupportedOperation(String),
+
+    #[error("Chain step {step} failed: {command}\n{stderr}")]
+    ChainStepFailed {
+        step: usize,
+        command: String,
+        stderr: String,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, BinfiddleError>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,9 @@ pub enum BinfiddleError {
     #[error("Operation not supported: {0}")]
     UnsupportedOperation(String),
 
+    #[error("Process memory error: {0}")]
+    ProcessMemoryError(String),
+
     #[error("Chain step {step} failed: {command}\n{stderr}")]
     ChainStepFailed {
         step: usize,

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,9 @@ pub enum BinfiddleError {
         command: String,
         stderr: String,
     },
+
+    #[error("Checksum verification failed")]
+    ChecksumVerificationFailed,
 }
 
 pub type Result<T> = std::result::Result<T, BinfiddleError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,13 @@ pub mod utils;
 use std::io::Read;
 
 pub use commands::{
-    parse_encoding, parse_ignore_ranges, AnalysisType, AnalyzeCommand, AnalyzeConfig,
-    AnalyzeOutputFormat, BitfieldDefinition, BomMode, Command, ConvertCommand, ConvertConfig,
-    DiffCommand, DiffConfig, DiffEntry, DiffFormat, EditCommand, EditOperation, Endianness,
-    ErrorMode, FieldDefinition, FieldType, NewlineMode, ParsedField, ParsedStruct, PatchCommand,
-    PatchConfig, PatchEntry, PatchResult, ReadCommand, SearchCommand, SearchConfig, StructCommand,
-    StructConfig, StructOutputFormat, StructTemplate, ValueOrExpression, WriteCommand,
+    chain::ChainExecutor, parse_encoding, parse_ignore_ranges, AnalysisType, AnalyzeCommand,
+    AnalyzeConfig, AnalyzeOutputFormat, BitfieldDefinition, BomMode, Command, ConvertCommand,
+    ConvertConfig, DiffCommand, DiffConfig, DiffEntry, DiffFormat, EditCommand, EditOperation,
+    Endianness, ErrorMode, FieldDefinition, FieldType, NewlineMode, ParsedField, ParsedStruct,
+    PatchCommand, PatchConfig, PatchEntry, PatchResult, ReadCommand, SearchCommand, SearchConfig,
+    StructCommand, StructConfig, StructOutputFormat, StructTemplate, ValueOrExpression,
+    WriteCommand,
 };
 pub use error::{BinfiddleError, Result};
 pub use utils::parsing::validate_search_pattern;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,12 +45,14 @@ pub enum BinarySource {
     ProcessSelf {
         address: u64,
         size: u64,
+        fill_mode: process_memory::FillMode,
     },
     /// Read memory from another process via `/proc/<pid>/mem`.
     Process {
         pid: u32,
         address: u64,
         size: u64,
+        fill_mode: process_memory::FillMode,
     },
     RawData(Vec<u8>),
 }
@@ -102,12 +104,17 @@ impl BinaryData {
                     "Memory address access not yet implemented".to_string(),
                 ));
             }
-            BinarySource::ProcessSelf { address, size } => {
-                process_memory::read_process_memory(0, *address, *size)?
-            }
-            BinarySource::Process { pid, address, size } => {
-                process_memory::read_process_memory(*pid, *address, *size)?
-            }
+            BinarySource::ProcessSelf {
+                address,
+                size,
+                fill_mode,
+            } => process_memory::read_process_memory_sparse(0, *address, *size, *fill_mode)?,
+            BinarySource::Process {
+                pid,
+                address,
+                size,
+                fill_mode,
+            } => process_memory::read_process_memory_sparse(*pid, *address, *size, *fill_mode)?,
             BinarySource::RawData(data) => data.clone(),
         };
 
@@ -340,6 +347,7 @@ mod tests {
             BinarySource::ProcessSelf {
                 address,
                 size: TEST_DATA.len() as u64,
+                fill_mode: process_memory::FillMode::Error,
             },
             8,
             16,
@@ -364,6 +372,7 @@ mod tests {
                 pid: std::process::id(),
                 address,
                 size: TEST_DATA.len() as u64,
+                fill_mode: process_memory::FillMode::Error,
             },
             8,
             16,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,39 @@ pub enum BinarySource {
     RawData(Vec<u8>),
 }
 
+/// Internal backing storage for [`BinaryData`].
+///
+/// File-backed data is mapped read-only with `memmap2`. Mutation methods lazily
+/// copy the mapped contents into an owned `Vec<u8>` before modifying them.
+#[derive(Debug)]
+enum DataBacking {
+    Owned(Vec<u8>),
+    Mmap(memmap2::Mmap),
+}
+
+impl DataBacking {
+    fn as_bytes(&self) -> &[u8] {
+        match self {
+            DataBacking::Owned(v) => v.as_slice(),
+            DataBacking::Mmap(m) => m.as_ref(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.as_bytes().len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.as_bytes().is_empty()
+    }
+}
+
+impl AsRef<[u8]> for DataBacking {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
 /// Represents a chunk of data with configurable bit length
 pub struct Chunk {
     data: Vec<u8>,
@@ -83,7 +116,7 @@ impl Chunk {
 
 /// Main struct representing the binary data being manipulated
 pub struct BinaryData {
-    data: Vec<u8>,
+    data: DataBacking,
     chunk_size: usize, // in bits
     width: usize,      // chunks per line
     source: BinarySource,
@@ -92,11 +125,23 @@ pub struct BinaryData {
 impl BinaryData {
     pub fn new(source: BinarySource, chunk_size: usize, width: usize) -> Result<Self> {
         let data = match &source {
-            BinarySource::File(path) => std::fs::read(path)?,
+            BinarySource::File(path) => {
+                let file = std::fs::File::open(path)?;
+                let metadata = file.metadata()?;
+                if metadata.len() == 0 {
+                    // memmap2 cannot map an empty file on all platforms, so keep it owned.
+                    DataBacking::Owned(Vec::new())
+                } else {
+                    // Safety: the file is opened read-only. The mapping is only read
+                    // until a mutation method is called, at which point the mapped
+                    // region is copied into an owned Vec before any writes occur.
+                    DataBacking::Mmap(unsafe { memmap2::Mmap::map(&file)? })
+                }
+            }
             BinarySource::Stdin => {
                 let mut buf = Vec::new();
                 std::io::stdin().read_to_end(&mut buf)?;
-                buf
+                DataBacking::Owned(buf)
             }
             BinarySource::MemoryAddress(_addr) => {
                 // Platform-specific implementation would go here
@@ -108,14 +153,18 @@ impl BinaryData {
                 address,
                 size,
                 fill_mode,
-            } => process_memory::read_process_memory_sparse(0, *address, *size, *fill_mode)?,
+            } => DataBacking::Owned(process_memory::read_process_memory_sparse(
+                0, *address, *size, *fill_mode,
+            )?),
             BinarySource::Process {
                 pid,
                 address,
                 size,
                 fill_mode,
-            } => process_memory::read_process_memory_sparse(*pid, *address, *size, *fill_mode)?,
-            BinarySource::RawData(data) => data.clone(),
+            } => DataBacking::Owned(process_memory::read_process_memory_sparse(
+                *pid, *address, *size, *fill_mode,
+            )?),
+            BinarySource::RawData(data) => DataBacking::Owned(data.clone()),
         };
 
         if chunk_size == 0 || (!data.is_empty() && chunk_size > data.len() * 8) {
@@ -140,8 +189,9 @@ impl BinaryData {
     }
 
     pub fn read_range(&self, start: usize, end: Option<usize>) -> Result<Chunk> {
-        let end = end.unwrap_or(self.data.len());
-        if start >= self.data.len() || end > self.data.len() || start >= end {
+        let bytes = self.data.as_bytes();
+        let end = end.unwrap_or(bytes.len());
+        if start >= bytes.len() || end > bytes.len() || start >= end {
             return Err(BinfiddleError::InvalidRange(format!(
                 "Invalid range [{}, {})",
                 start, end
@@ -156,40 +206,71 @@ impl BinaryData {
             self.chunk_size
         };
 
-        Chunk::new(self.data[start..end].to_vec(), effective_chunk_size)
+        Chunk::new(bytes[start..end].to_vec(), effective_chunk_size)
+    }
+
+    /// Ensures the backing storage is an owned `Vec<u8>`.
+    ///
+    /// This is called lazily by mutation methods so that read-only operations on
+    /// file-backed data can keep using the memory-mapped region.
+    fn ensure_owned(&mut self) {
+        if matches!(&self.data, DataBacking::Mmap(_)) {
+            let old = std::mem::replace(&mut self.data, DataBacking::Owned(Vec::new()));
+            if let DataBacking::Mmap(mmap) = old {
+                self.data = DataBacking::Owned(mmap.as_ref().to_vec());
+            }
+        }
     }
 
     pub fn write_range(&mut self, start: usize, data: &[u8]) -> Result<()> {
-        if start + data.len() > self.data.len() {
+        self.ensure_owned();
+        let bytes = match &mut self.data {
+            DataBacking::Owned(v) => v.as_mut_slice(),
+            DataBacking::Mmap(_) => unreachable!("ensure_owned just converted Mmap to Owned"),
+        };
+
+        if start + data.len() > bytes.len() {
             return Err(BinfiddleError::InvalidRange(
                 "Write operation would exceed data bounds".to_string(),
             ));
         }
 
-        self.data[start..start + data.len()].copy_from_slice(data);
+        bytes[start..start + data.len()].copy_from_slice(data);
         Ok(())
     }
 
     pub fn insert_data(&mut self, position: usize, data: &[u8]) -> Result<()> {
-        if position > self.data.len() {
+        self.ensure_owned();
+        let vec = match &mut self.data {
+            DataBacking::Owned(v) => v,
+            DataBacking::Mmap(_) => unreachable!("ensure_owned just converted Mmap to Owned"),
+        };
+
+        if position > vec.len() {
             return Err(BinfiddleError::InvalidRange(
                 "Insert position out of bounds".to_string(),
             ));
         }
 
-        self.data.splice(position..position, data.iter().cloned());
+        vec.splice(position..position, data.iter().cloned());
         Ok(())
     }
 
     pub fn remove_range(&mut self, start: usize, end: usize) -> Result<()> {
-        if start >= self.data.len() || end > self.data.len() || start >= end {
+        self.ensure_owned();
+        let vec = match &mut self.data {
+            DataBacking::Owned(v) => v,
+            DataBacking::Mmap(_) => unreachable!("ensure_owned just converted Mmap to Owned"),
+        };
+
+        if start >= vec.len() || end > vec.len() || start >= end {
             return Err(BinfiddleError::InvalidRange(format!(
                 "Invalid range [{}, {})",
                 start, end
             )));
         }
 
-        self.data.drain(start..end);
+        vec.drain(start..end);
         Ok(())
     }
 
@@ -219,6 +300,7 @@ impl BinaryData {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
 
     #[test]
     fn test_empty_binarydata_with_default_chunk_size() {
@@ -385,5 +467,45 @@ mod tests {
                 .get_bytes(),
             &TEST_DATA[..]
         );
+    }
+
+    #[test]
+    fn test_file_backed_binarydata_reads_via_mmap() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"hello mmap").unwrap();
+        let path = tmp.path().to_path_buf();
+
+        let data = BinaryData::new(BinarySource::File(path), 8, 16).unwrap();
+        assert_eq!(data.len(), 10);
+        assert_eq!(data.read_range(0, Some(5)).unwrap().get_bytes(), b"hello");
+        assert_eq!(data.read_range(6, Some(10)).unwrap().get_bytes(), b"mmap");
+    }
+
+    #[test]
+    fn test_empty_file_binarydata() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+
+        let data = BinaryData::new(BinarySource::File(path), 8, 16).unwrap();
+        assert_eq!(data.len(), 0);
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn test_file_backed_mutation_converts_to_owned() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"ABCD").unwrap();
+        let path = tmp.path().to_path_buf();
+
+        let mut data = BinaryData::new(BinarySource::File(path), 8, 16).unwrap();
+        data.write_range(0, b"XYZ").unwrap();
+        assert_eq!(data.read_range(0, Some(4)).unwrap().get_bytes(), b"XYZD");
+
+        // Insert/remove also work after the conversion.
+        data.insert_data(4, b"!").unwrap();
+        assert_eq!(data.read_range(0, None).unwrap().get_bytes(), b"XYZD!");
+
+        data.remove_range(3, 4).unwrap();
+        assert_eq!(data.read_range(0, None).unwrap().get_bytes(), b"XYZ!");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,10 @@
 /// src/lib.rs
 pub mod commands;
 pub mod error;
+pub mod process_memory;
 pub mod utils;
 
-use std::io::{Read, Seek, SeekFrom};
+use std::io::Read;
 
 pub use commands::{
     chain::ChainExecutor, parse_encoding, parse_ignore_ranges, AnalysisType, AnalyzeCommand,
@@ -35,12 +36,19 @@ pub enum ColorMode {
 }
 
 /// Represents the input source for binary data
+#[derive(Debug, Clone)]
 pub enum BinarySource {
     File(std::path::PathBuf),
     Stdin,
     MemoryAddress(usize),
     /// Read memory from the current process via `/proc/self/mem`.
     ProcessSelf {
+        address: u64,
+        size: u64,
+    },
+    /// Read memory from another process via `/proc/<pid>/mem`.
+    Process {
+        pid: u32,
         address: u64,
         size: u64,
     },
@@ -76,11 +84,12 @@ pub struct BinaryData {
     data: Vec<u8>,
     chunk_size: usize, // in bits
     width: usize,      // chunks per line
+    source: BinarySource,
 }
 
 impl BinaryData {
     pub fn new(source: BinarySource, chunk_size: usize, width: usize) -> Result<Self> {
-        let data = match source {
+        let data = match &source {
             BinarySource::File(path) => std::fs::read(path)?,
             BinarySource::Stdin => {
                 let mut buf = Vec::new();
@@ -93,8 +102,13 @@ impl BinaryData {
                     "Memory address access not yet implemented".to_string(),
                 ));
             }
-            BinarySource::ProcessSelf { address, size } => read_process_self(address, size)?,
-            BinarySource::RawData(data) => data,
+            BinarySource::ProcessSelf { address, size } => {
+                process_memory::read_process_memory(0, *address, *size)?
+            }
+            BinarySource::Process { pid, address, size } => {
+                process_memory::read_process_memory(*pid, *address, *size)?
+            }
+            BinarySource::RawData(data) => data.clone(),
         };
 
         if chunk_size == 0 || (!data.is_empty() && chunk_size > data.len() * 8) {
@@ -105,7 +119,13 @@ impl BinaryData {
             data,
             chunk_size,
             width,
+            source,
         })
+    }
+
+    /// Returns the original source used to load this data.
+    pub fn source(&self) -> &BinarySource {
+        &self.source
     }
 
     pub fn get_width(&self) -> usize {
@@ -177,53 +197,6 @@ impl BinaryData {
         self.chunk_size = chunk_size;
         Ok(())
     }
-}
-
-/// Reads memory from the current process via `/proc/self/mem`.
-///
-/// Linux-only. This is intentionally minimal: no region enumeration, no
-/// cross-process support, and no writes. Failures are surfaced as
-/// `BinfiddleError::ProcessMemoryError`.
-fn read_process_self(address: u64, size: u64) -> Result<Vec<u8>> {
-    use std::fs::File;
-
-    if size > usize::MAX as u64 {
-        return Err(BinfiddleError::ProcessMemoryError(
-            "Requested size exceeds addressable memory".to_string(),
-        ));
-    }
-    let size = size as usize;
-
-    let mut file = File::open("/proc/self/mem").map_err(|e| {
-        BinfiddleError::ProcessMemoryError(format!("Failed to open /proc/self/mem: {}", e))
-    })?;
-
-    file.seek(SeekFrom::Start(address)).map_err(|e| {
-        BinfiddleError::ProcessMemoryError(format!(
-            "Failed to seek to address 0x{:x}: {}",
-            address, e
-        ))
-    })?;
-
-    let mut buffer = vec![0u8; size];
-    let mut total_read = 0usize;
-
-    while total_read < size {
-        match file.read(&mut buffer[total_read..]) {
-            Ok(0) => break,
-            Ok(n) => total_read += n,
-            Err(e) => {
-                return Err(BinfiddleError::ProcessMemoryError(format!(
-                    "Failed to read process memory at 0x{:x}: {}",
-                    address + total_read as u64,
-                    e
-                )));
-            }
-        }
-    }
-
-    buffer.truncate(total_read);
-    Ok(buffer)
 }
 
 impl BinaryData {
@@ -372,6 +345,30 @@ mod tests {
             16,
         )
         .expect("should read /proc/self/mem");
+
+        assert_eq!(
+            data.read_range(0, Some(TEST_DATA.len()))
+                .unwrap()
+                .get_bytes(),
+            &TEST_DATA[..]
+        );
+    }
+
+    #[test]
+    fn test_read_process_by_pid() {
+        static TEST_DATA: [u8; 8] = *b"PIDMEM!!";
+        let address = &TEST_DATA as *const _ as u64;
+
+        let data = BinaryData::new(
+            BinarySource::Process {
+                pid: std::process::id(),
+                address,
+                size: TEST_DATA.len() as u64,
+            },
+            8,
+            16,
+        )
+        .expect("should read /proc/<pid>/mem");
 
         assert_eq!(
             data.read_range(0, Some(TEST_DATA.len()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,6 +295,14 @@ impl BinaryData {
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()
     }
+
+    /// Returns an immutable view of the underlying bytes.
+    ///
+    /// For file-backed data this is a slice into the memory-mapped region, so
+    /// callers do not trigger a full copy of the file.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.data.as_bytes()
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,11 @@ use std::io::Read;
 
 pub use commands::{
     parse_encoding, parse_ignore_ranges, AnalysisType, AnalyzeCommand, AnalyzeConfig,
-    AnalyzeOutputFormat, BomMode, Command, ConvertCommand, ConvertConfig, DiffCommand, DiffConfig,
-    DiffEntry, DiffFormat, EditCommand, EditOperation, Endianness, ErrorMode, FieldDefinition,
-    FieldType, NewlineMode, ParsedField, ParsedStruct, PatchCommand, PatchConfig, PatchEntry,
-    PatchResult, ReadCommand, SearchCommand, SearchConfig, StructCommand, StructConfig,
-    StructOutputFormat, StructTemplate, WriteCommand,
+    AnalyzeOutputFormat, BitfieldDefinition, BomMode, Command, ConvertCommand, ConvertConfig,
+    DiffCommand, DiffConfig, DiffEntry, DiffFormat, EditCommand, EditOperation, Endianness,
+    ErrorMode, FieldDefinition, FieldType, NewlineMode, ParsedField, ParsedStruct, PatchCommand,
+    PatchConfig, PatchEntry, PatchResult, ReadCommand, SearchCommand, SearchConfig, StructCommand,
+    StructConfig, StructOutputFormat, StructTemplate, ValueOrExpression, WriteCommand,
 };
 pub use error::{BinfiddleError, Result};
 pub use utils::parsing::validate_search_pattern;
@@ -22,20 +22,15 @@ pub use utils::{
 };
 
 /// Color output mode for terminal display.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ColorMode {
     /// Always use colors, even if output is not a terminal
     Always,
     /// Automatically detect if terminal supports colors
+    #[default]
     Auto,
     /// Never use colors
     Never,
-}
-
-impl Default for ColorMode {
-    fn default() -> Self {
-        ColorMode::Auto
-    }
 }
 
 /// Represents the input source for binary data
@@ -95,7 +90,7 @@ impl BinaryData {
             BinarySource::RawData(data) => data,
         };
 
-        if chunk_size == 0 || (data.len() > 0 && chunk_size > data.len() * 8) {
+        if chunk_size == 0 || (!data.is_empty() && chunk_size > data.len() * 8) {
             return Err(BinfiddleError::InvalidChunkSize(chunk_size));
         }
 
@@ -169,7 +164,7 @@ impl BinaryData {
     }
 
     pub fn set_chunk_size(&mut self, chunk_size: usize) -> Result<()> {
-        if chunk_size == 0 || (self.data.len() > 0 && chunk_size > self.data.len() * 8) {
+        if chunk_size == 0 || (!self.data.is_empty() && chunk_size > self.data.len() * 8) {
             return Err(BinfiddleError::InvalidChunkSize(chunk_size));
         }
         self.chunk_size = chunk_size;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,10 @@ pub use commands::{
     chain::ChainExecutor, parse_encoding, parse_ignore_ranges, AnalysisType, AnalyzeCommand,
     AnalyzeConfig, AnalyzeOutputFormat, BitfieldDefinition, BomMode, Command, ConvertCommand,
     ConvertConfig, DiffCommand, DiffConfig, DiffEntry, DiffFormat, EditCommand, EditOperation,
-    Endianness, ErrorMode, FieldDefinition, FieldType, NewlineMode, ParsedField, ParsedStruct,
-    PatchCommand, PatchConfig, PatchEntry, PatchResult, ReadCommand, SearchCommand, SearchConfig,
-    StructCommand, StructConfig, StructOutputFormat, StructTemplate, ValueOrExpression,
-    WriteCommand,
+    Endianness, ErrorMode, FieldDefinition, FieldType, HashAlgorithm, HashCommand, HashConfig,
+    HashOutputFormat, NewlineMode, ParsedField, ParsedStruct, PatchCommand, PatchConfig,
+    PatchEntry, PatchResult, ReadCommand, SearchCommand, SearchConfig, StructCommand, StructConfig,
+    StructOutputFormat, StructTemplate, ValueOrExpression, WriteCommand,
 };
 pub use error::{BinfiddleError, Result};
 pub use utils::parsing::validate_search_pattern;
@@ -39,6 +39,8 @@ pub enum ColorMode {
 #[derive(Debug, Clone)]
 pub enum BinarySource {
     File(std::path::PathBuf),
+    /// File opened read-write for in-place mutation via a mutable memory map.
+    WritableFile(std::path::PathBuf),
     Stdin,
     MemoryAddress(usize),
     /// Read memory from the current process via `/proc/self/mem`.
@@ -60,11 +62,14 @@ pub enum BinarySource {
 /// Internal backing storage for [`BinaryData`].
 ///
 /// File-backed data is mapped read-only with `memmap2`. Mutation methods lazily
-/// copy the mapped contents into an owned `Vec<u8>` before modifying them.
+/// copy the mapped contents into an owned `Vec<u8>` before modifying them, except
+/// for in-place writes via [`BinarySource::WritableFile`], which use a mutable
+/// memory map and flush changes directly back to disk.
 #[derive(Debug)]
 enum DataBacking {
     Owned(Vec<u8>),
     Mmap(memmap2::Mmap),
+    MmapMut(memmap2::MmapMut),
 }
 
 impl DataBacking {
@@ -72,6 +77,7 @@ impl DataBacking {
         match self {
             DataBacking::Owned(v) => v.as_slice(),
             DataBacking::Mmap(m) => m.as_ref(),
+            DataBacking::MmapMut(m) => m.as_ref(),
         }
     }
 
@@ -136,6 +142,22 @@ impl BinaryData {
                     // until a mutation method is called, at which point the mapped
                     // region is copied into an owned Vec before any writes occur.
                     DataBacking::Mmap(unsafe { memmap2::Mmap::map(&file)? })
+                }
+            }
+            BinarySource::WritableFile(path) => {
+                let file = std::fs::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(path)?;
+                let metadata = file.metadata()?;
+                if metadata.len() == 0 {
+                    DataBacking::Owned(Vec::new())
+                } else {
+                    // Safety: the file is opened read-write and the mapping is flushed
+                    // before any other process observes the changes. Size-changing edits
+                    // copy the data into an owned Vec first, so the mutable map is only
+                    // used for fixed-size in-place writes.
+                    DataBacking::MmapMut(unsafe { memmap2::MmapMut::map_mut(&file)? })
                 }
             }
             BinarySource::Stdin => {
@@ -214,36 +236,62 @@ impl BinaryData {
     /// This is called lazily by mutation methods so that read-only operations on
     /// file-backed data can keep using the memory-mapped region.
     fn ensure_owned(&mut self) {
-        if matches!(&self.data, DataBacking::Mmap(_)) {
+        if matches!(&self.data, DataBacking::Mmap(_) | DataBacking::MmapMut(_)) {
             let old = std::mem::replace(&mut self.data, DataBacking::Owned(Vec::new()));
-            if let DataBacking::Mmap(mmap) = old {
-                self.data = DataBacking::Owned(mmap.as_ref().to_vec());
+            match old {
+                DataBacking::Mmap(mmap) => {
+                    self.data = DataBacking::Owned(mmap.as_ref().to_vec());
+                }
+                DataBacking::MmapMut(mmap) => {
+                    self.data = DataBacking::Owned(mmap.as_ref().to_vec());
+                }
+                DataBacking::Owned(_) => unreachable!("replace produced an empty Owned"),
             }
         }
     }
 
     pub fn write_range(&mut self, start: usize, data: &[u8]) -> Result<()> {
-        self.ensure_owned();
-        let bytes = match &mut self.data {
-            DataBacking::Owned(v) => v.as_mut_slice(),
-            DataBacking::Mmap(_) => unreachable!("ensure_owned just converted Mmap to Owned"),
-        };
+        let data_len = data.len();
+        match &mut self.data {
+            DataBacking::MmapMut(mmap) => {
+                let bytes = mmap.as_mut();
+                if start + data_len > bytes.len() {
+                    return Err(BinfiddleError::InvalidRange(
+                        "Write operation would exceed data bounds".to_string(),
+                    ));
+                }
+                bytes[start..start + data_len].copy_from_slice(data);
+                mmap.flush()?;
+                Ok(())
+            }
+            _ => {
+                self.ensure_owned();
+                let bytes = match &mut self.data {
+                    DataBacking::Owned(v) => v.as_mut_slice(),
+                    DataBacking::Mmap(_) | DataBacking::MmapMut(_) => {
+                        unreachable!("ensure_owned just converted backing to Owned")
+                    }
+                };
 
-        if start + data.len() > bytes.len() {
-            return Err(BinfiddleError::InvalidRange(
-                "Write operation would exceed data bounds".to_string(),
-            ));
+                if start + data_len > bytes.len() {
+                    return Err(BinfiddleError::InvalidRange(
+                        "Write operation would exceed data bounds".to_string(),
+                    ));
+                }
+
+                bytes[start..start + data_len].copy_from_slice(data);
+                Ok(())
+            }
         }
-
-        bytes[start..start + data.len()].copy_from_slice(data);
-        Ok(())
     }
 
     pub fn insert_data(&mut self, position: usize, data: &[u8]) -> Result<()> {
         self.ensure_owned();
         let vec = match &mut self.data {
             DataBacking::Owned(v) => v,
-            DataBacking::Mmap(_) => unreachable!("ensure_owned just converted Mmap to Owned"),
+            DataBacking::Mmap(_) | DataBacking::MmapMut(_) => {
+                unreachable!("ensure_owned just converted backing to Owned")
+            }
         };
 
         if position > vec.len() {
@@ -260,7 +308,9 @@ impl BinaryData {
         self.ensure_owned();
         let vec = match &mut self.data {
             DataBacking::Owned(v) => v,
-            DataBacking::Mmap(_) => unreachable!("ensure_owned just converted Mmap to Owned"),
+            DataBacking::Mmap(_) | DataBacking::MmapMut(_) => {
+                unreachable!("ensure_owned just converted backing to Owned")
+            }
         };
 
         if start >= vec.len() || end > vec.len() || start >= end {
@@ -515,5 +565,41 @@ mod tests {
 
         data.remove_range(3, 4).unwrap();
         assert_eq!(data.read_range(0, None).unwrap().get_bytes(), b"XYZ!");
+    }
+
+    #[test]
+    fn test_writable_file_in_place_write() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"HELLO WORLD").unwrap();
+        let path = tmp.path().to_path_buf();
+
+        let mut data = BinaryData::new(BinarySource::WritableFile(path.clone()), 8, 16).unwrap();
+        data.write_range(6, b"EARTH").unwrap();
+
+        // In-memory view reflects the write.
+        assert_eq!(
+            data.read_range(0, None).unwrap().get_bytes(),
+            b"HELLO EARTH"
+        );
+
+        // The change is also visible on disk without an explicit save.
+        let on_disk = std::fs::read(&path).unwrap();
+        assert_eq!(on_disk, b"HELLO EARTH");
+    }
+
+    #[test]
+    fn test_writable_file_size_changing_edit_falls_back_to_owned() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"ABCD").unwrap();
+        let path = tmp.path().to_path_buf();
+
+        let mut data = BinaryData::new(BinarySource::WritableFile(path.clone()), 8, 16).unwrap();
+        // Insert forces a copy because the mapped region cannot grow.
+        data.insert_data(4, b"EF").unwrap();
+        assert_eq!(data.read_range(0, None).unwrap().get_bytes(), b"ABCDEF");
+
+        // The file on disk is unchanged until we write it back explicitly.
+        let on_disk = std::fs::read(&path).unwrap();
+        assert_eq!(on_disk, b"ABCD");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ pub mod commands;
 pub mod error;
 pub mod utils;
 
-use std::io::Read;
+use std::io::{Read, Seek, SeekFrom};
 
 pub use commands::{
     chain::ChainExecutor, parse_encoding, parse_ignore_ranges, AnalysisType, AnalyzeCommand,
@@ -39,6 +39,11 @@ pub enum BinarySource {
     File(std::path::PathBuf),
     Stdin,
     MemoryAddress(usize),
+    /// Read memory from the current process via `/proc/self/mem`.
+    ProcessSelf {
+        address: u64,
+        size: u64,
+    },
     RawData(Vec<u8>),
 }
 
@@ -88,6 +93,7 @@ impl BinaryData {
                     "Memory address access not yet implemented".to_string(),
                 ));
             }
+            BinarySource::ProcessSelf { address, size } => read_process_self(address, size)?,
             BinarySource::RawData(data) => data,
         };
 
@@ -171,7 +177,56 @@ impl BinaryData {
         self.chunk_size = chunk_size;
         Ok(())
     }
+}
 
+/// Reads memory from the current process via `/proc/self/mem`.
+///
+/// Linux-only. This is intentionally minimal: no region enumeration, no
+/// cross-process support, and no writes. Failures are surfaced as
+/// `BinfiddleError::ProcessMemoryError`.
+fn read_process_self(address: u64, size: u64) -> Result<Vec<u8>> {
+    use std::fs::File;
+
+    if size > usize::MAX as u64 {
+        return Err(BinfiddleError::ProcessMemoryError(
+            "Requested size exceeds addressable memory".to_string(),
+        ));
+    }
+    let size = size as usize;
+
+    let mut file = File::open("/proc/self/mem").map_err(|e| {
+        BinfiddleError::ProcessMemoryError(format!("Failed to open /proc/self/mem: {}", e))
+    })?;
+
+    file.seek(SeekFrom::Start(address)).map_err(|e| {
+        BinfiddleError::ProcessMemoryError(format!(
+            "Failed to seek to address 0x{:x}: {}",
+            address, e
+        ))
+    })?;
+
+    let mut buffer = vec![0u8; size];
+    let mut total_read = 0usize;
+
+    while total_read < size {
+        match file.read(&mut buffer[total_read..]) {
+            Ok(0) => break,
+            Ok(n) => total_read += n,
+            Err(e) => {
+                return Err(BinfiddleError::ProcessMemoryError(format!(
+                    "Failed to read process memory at 0x{:x}: {}",
+                    address + total_read as u64,
+                    e
+                )));
+            }
+        }
+    }
+
+    buffer.truncate(total_read);
+    Ok(buffer)
+}
+
+impl BinaryData {
     pub fn len(&self) -> usize {
         self.data.len()
     }
@@ -299,6 +354,30 @@ mod tests {
         assert!(
             dummy_data.is_ok(),
             "Diff command's dummy BinaryData creation should succeed"
+        );
+    }
+
+    #[test]
+    fn test_read_process_self() {
+        // A static with a known magic value so we can look it up in /proc/self/mem.
+        static TEST_DATA: [u8; 8] = *b"BINFIDL!";
+        let address = &TEST_DATA as *const _ as u64;
+
+        let data = BinaryData::new(
+            BinarySource::ProcessSelf {
+                address,
+                size: TEST_DATA.len() as u64,
+            },
+            8,
+            16,
+        )
+        .expect("should read /proc/self/mem");
+
+        assert_eq!(
+            data.read_range(0, Some(TEST_DATA.len()))
+                .unwrap()
+                .get_bytes(),
+            &TEST_DATA[..]
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,22 +9,34 @@ use std::io::{self, Read, Write};
 #[command(version, about, long_about = None)]
 struct Cli {
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 
     /// Input file (use '-' for stdin)
     #[arg(short, long, group = "source")]
     input: Option<String>,
 
     /// Read from current process memory via /proc/self/mem (Linux only)
-    #[arg(long, group = "source", requires = "address", requires = "size")]
+    #[arg(long, group = "source")]
     process_self: bool,
 
-    /// Base address to read from when using --process-self (hex or decimal)
-    #[arg(long, requires = "process_self")]
+    /// Read from a process's memory via /proc/<pid>/mem (Linux only)
+    #[arg(long, group = "source")]
+    pid: Option<u32>,
+
+    /// List memory regions of the target process instead of running a command
+    #[arg(long)]
+    list_regions: bool,
+
+    /// Allow writing back to process memory (current process only)
+    #[arg(long)]
+    allow_write: bool,
+
+    /// Base address to read from when using --process-self or --pid (hex or decimal)
+    #[arg(long)]
     address: Option<String>,
 
-    /// Number of bytes to read when using --process-self (hex or decimal)
-    #[arg(long, requires = "process_self")]
+    /// Number of bytes to read when using --process-self or --pid (hex or decimal)
+    #[arg(long)]
     size: Option<String>,
 
     /// Modify file directly (requires input file)
@@ -257,11 +269,15 @@ enum Commands {
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
+    // Resolve the effective process-memory target pid, if any.
+    let target_pid = if cli.process_self { Some(0) } else { cli.pid };
+    let source_is_process_memory = target_pid.is_some();
+
     // Handle chain command early, before normal input loading.
-    if let Commands::Chain { step } = &cli.command {
-        if cli.process_self {
+    if let Some(Commands::Chain { step }) = &cli.command {
+        if source_is_process_memory {
             return Err(BinfiddleError::InvalidInput(
-                "--process-self cannot be used with chain".to_string(),
+                "--process-self and --pid cannot be used with chain".to_string(),
             ));
         }
         return binfiddle::ChainExecutor::execute(
@@ -272,9 +288,35 @@ fn main() -> Result<()> {
         );
     }
 
+    // Handle --list-regions before loading binary data.
+    if cli.list_regions {
+        let pid = target_pid.unwrap_or(0);
+        let regions = binfiddle::process_memory::parse_maps(pid)?;
+        print!("{}", binfiddle::process_memory::format_regions(&regions));
+        return Ok(());
+    }
+
+    let command = cli.command.as_ref().ok_or_else(|| {
+        BinfiddleError::InvalidInput("A subcommand is required (or use --list-regions)".to_string())
+    })?;
+
+    // Validate process-memory args.
+    if source_is_process_memory {
+        if cli.address.is_none() {
+            return Err(BinfiddleError::InvalidInput(
+                "--address is required when using --process-self or --pid".to_string(),
+            ));
+        }
+        if cli.size.is_none() {
+            return Err(BinfiddleError::InvalidInput(
+                "--size is required when using --process-self or --pid".to_string(),
+            ));
+        }
+    }
+
     // Check if this command needs binary_data loaded
     let needs_input = matches!(
-        cli.command,
+        command,
         Commands::Read { .. }
             | Commands::Write { .. }
             | Commands::Edit { .. }
@@ -285,19 +327,15 @@ fn main() -> Result<()> {
 
     // Load data only for commands that need it
     let mut binary_data = if needs_input {
-        if cli.process_self {
-            let address = parse_address_or_size(
-                cli.address
-                    .as_deref()
-                    .expect("clap ensures address is present"),
-            )?;
-            let size =
-                parse_address_or_size(cli.size.as_deref().expect("clap ensures size is present"))?;
-            BinaryData::new(
-                BinarySource::ProcessSelf { address, size },
-                cli.chunk_size,
-                cli.width,
-            )?
+        if let Some(pid) = target_pid {
+            let address = parse_address_or_size(cli.address.as_deref().unwrap())?;
+            let size = parse_address_or_size(cli.size.as_deref().unwrap())?;
+            let source = if pid == 0 {
+                BinarySource::ProcessSelf { address, size }
+            } else {
+                BinarySource::Process { pid, address, size }
+            };
+            BinaryData::new(source, cli.chunk_size, cli.width)?
         } else {
             match cli.input.as_deref() {
                 Some("-") | None => {
@@ -315,11 +353,8 @@ fn main() -> Result<()> {
         BinaryData::new(BinarySource::RawData(Vec::new()), cli.chunk_size, cli.width)?
     };
 
-    // Remember whether the source is process memory so we can reject writes later.
-    let source_is_process_self = cli.process_self;
-
     // Execute command
-    let changes_made = match &cli.command {
+    let changes_made = match command {
         Commands::Read { range } => {
             let (start, end) = binfiddle::utils::parsing::parse_range(range, binary_data.len())?;
             let chunk = binary_data.read_range(start, end)?;
@@ -826,14 +861,32 @@ fn main() -> Result<()> {
 
     // Handle output
     if changes_made {
-        if source_is_process_self {
-            return Err(BinfiddleError::UnsupportedOperation(
-                "Writing to process memory is not supported in this version. \
-                 Use --output to write the result to a file."
-                    .to_string(),
-            ));
-        }
-        if cli.in_file {
+        if source_is_process_memory {
+            if !cli.allow_write {
+                return Err(BinfiddleError::ProcessMemoryError(
+                    "Writing to process memory requires --allow-write".to_string(),
+                ));
+            }
+
+            let (pid, address, original_size) = match binary_data.source() {
+                BinarySource::ProcessSelf { address, size } => (0, *address, *size as usize),
+                BinarySource::Process { pid, address, size } => (*pid, *address, *size as usize),
+                _ => unreachable!(),
+            };
+
+            if binary_data.len() != original_size {
+                return Err(BinfiddleError::ProcessMemoryError(
+                    "Process memory write would change region size; insert/remove are not supported"
+                        .to_string(),
+                ));
+            }
+
+            binfiddle::process_memory::write_process_memory(
+                pid,
+                address,
+                binary_data.read_range(0, None)?.get_bytes(),
+            )?;
+        } else if cli.in_file {
             if let Some(path) = &cli.input {
                 std::fs::write(path, binary_data.read_range(0, None)?.get_bytes())?;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,10 @@ struct Cli {
     #[arg(long)]
     silent: bool,
 
+    /// Show progress bars for long-running commands
+    #[arg(long)]
+    progress: bool,
+
     /// Chunk size in bits (default: 8)
     #[arg(short, long, default_value = "8")]
     chunk_size: usize,
@@ -450,7 +454,7 @@ fn main() -> Result<()> {
             }
         };
 
-        let progress = Progress::new(total, "Searching", cli.silent);
+        let progress = Progress::new(total, "Searching", cli.progress && !cli.silent);
         let input = ProgressReader::new(input, progress);
 
         let matches = search_cmd.search_stream(input, block_size)?;
@@ -510,7 +514,7 @@ fn main() -> Result<()> {
                 }
             };
 
-            let progress = Progress::new(total, "Analyzing", cli.silent);
+            let progress = Progress::new(total, "Analyzing", cli.progress && !cli.silent);
             let input = ProgressReader::new(input, progress);
 
             let output = analyze_cmd.analyze_stream(input)?;
@@ -555,7 +559,7 @@ fn main() -> Result<()> {
                 }
             };
 
-            let progress = Progress::new(total, "Hashing", cli.silent);
+            let progress = Progress::new(total, "Hashing", cli.progress && !cli.silent);
             let input = ProgressReader::new(input, progress);
 
             let output = hash_cmd.compute_stream(input, read_chunk_size)?;
@@ -802,7 +806,11 @@ fn main() -> Result<()> {
 
             // Show a spinner for full scans, which can be slow on large files.
             let progress = if *all {
-                Some(Progress::new(None, "Searching", cli.silent))
+                Some(Progress::new(
+                    None,
+                    "Searching",
+                    cli.progress && !cli.silent,
+                ))
             } else {
                 None
             };
@@ -863,12 +871,12 @@ fn main() -> Result<()> {
             // Show progress for block-based analysis; use a spinner otherwise.
             let output = if config.block_size > 0 && config.range.is_none() {
                 let total = Some(bytes.len() as u64);
-                let progress = Progress::new(total, "Analyzing", cli.silent);
+                let progress = Progress::new(total, "Analyzing", cli.progress && !cli.silent);
                 let cursor = std::io::Cursor::new(bytes);
                 let reader = ProgressReader::new(cursor, progress);
                 analyze_cmd.analyze_stream(reader)?
             } else {
-                let progress = Progress::new(None, "Analyzing", cli.silent);
+                let progress = Progress::new(None, "Analyzing", cli.progress && !cli.silent);
                 let result = analyze_cmd.analyze(bytes)?;
                 progress.finish();
                 result
@@ -901,7 +909,7 @@ fn main() -> Result<()> {
             // showing a progress bar for large inputs.
             let bytes = binary_data.as_bytes();
             let total = Some(bytes.len() as u64);
-            let progress = Progress::new(total, "Hashing", cli.silent);
+            let progress = Progress::new(total, "Hashing", cli.progress && !cli.silent);
             let cursor = std::io::Cursor::new(bytes);
             let reader = ProgressReader::new(cursor, progress);
             let output = hash_cmd.compute_stream(reader, 1024 * 1024)?;
@@ -1035,7 +1043,7 @@ fn main() -> Result<()> {
             let bytes = binary_data.as_bytes();
 
             // Show a spinner because conversion can take a while on large files.
-            let progress = Progress::new(None, "Converting", cli.silent);
+            let progress = Progress::new(None, "Converting", cli.progress && !cli.silent);
 
             // Perform conversion
             let converted = convert_cmd.convert(bytes)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,16 +124,24 @@ enum Commands {
 
     /// Compute a hash digest of the binary data
     Hash {
-        /// Hash algorithm: md5, sha256, blake3, crc32
+        /// Hash algorithm: md5, sha1, sha256, blake3, crc32, xxhash64
         algorithm: String,
 
-        /// Output format: hex
-        #[arg(long, default_value = "hex", value_parser = ["hex"])]
+        /// Output format: hex, base64
+        #[arg(long, default_value = "hex", value_parser = ["hex", "base64"])]
         output_format: String,
 
         /// Block size for block-based hashing (0 = whole file)
         #[arg(long, default_value = "0")]
         block_size: usize,
+
+        /// Stream the input instead of memory-mapping (for huge files)
+        #[arg(long)]
+        stream: bool,
+
+        /// Read chunk size when streaming (supports K/M/G suffixes, default 1M)
+        #[arg(long, default_value = "1M")]
+        read_block_size: String,
     },
 
     /// Search for patterns in binary data
@@ -492,6 +500,43 @@ fn main() -> Result<()> {
         }
     }
 
+    // Handle streaming hash before loading binary data.
+    if let Commands::Hash {
+        algorithm,
+        output_format,
+        block_size,
+        stream,
+        read_block_size,
+    } = command
+    {
+        if *stream {
+            if source_is_process_memory {
+                return Err(BinfiddleError::InvalidInput(
+                    "--stream hashing cannot be used with --process-self or --pid".to_string(),
+                ));
+            }
+
+            let algorithm = algorithm.parse::<binfiddle::HashAlgorithm>()?;
+            let output_format = output_format.parse::<binfiddle::HashOutputFormat>()?;
+            let config = binfiddle::HashConfig {
+                algorithm,
+                output_format,
+                block_size: *block_size,
+            };
+            let hash_cmd = binfiddle::HashCommand::new(config);
+
+            let read_chunk_size = parse_byte_size(read_block_size)?;
+            let input: Box<dyn Read> = match cli.input.as_deref() {
+                Some("-") | None => Box::new(io::stdin()),
+                Some(path) => Box::new(std::fs::File::open(path)?),
+            };
+
+            let output = hash_cmd.compute_stream(input, read_chunk_size)?;
+            println!("{}", output);
+            return Ok(());
+        }
+    }
+
     // Check if this command needs binary_data loaded
     let needs_input = matches!(
         command,
@@ -754,6 +799,8 @@ fn main() -> Result<()> {
             algorithm,
             output_format,
             block_size,
+            stream: _,
+            read_block_size: _,
         } => {
             let algorithm = algorithm.parse::<binfiddle::HashAlgorithm>()?;
             let output_format = output_format.parse::<binfiddle::HashOutputFormat>()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -546,9 +546,8 @@ fn main() -> Result<()> {
             // Create and execute search command
             let search_cmd = binfiddle::SearchCommand::new(config);
 
-            // Read all data for searching
-            let chunk = binary_data.read_range(0, None)?;
-            let bytes = chunk.get_bytes();
+            // Search directly against the backing bytes without copying the whole file.
+            let bytes = binary_data.as_bytes();
 
             // Perform search
             let matches = search_cmd.search(bytes)?;
@@ -597,9 +596,8 @@ fn main() -> Result<()> {
             // Create and execute analyze command
             let analyze_cmd = binfiddle::AnalyzeCommand::new(config);
 
-            // Read all data for analysis
-            let chunk = binary_data.read_range(0, None)?;
-            let bytes = chunk.get_bytes();
+            // Analyze directly against the backing bytes without copying the whole file.
+            let bytes = binary_data.as_bytes();
 
             // Perform analysis and print results
             let output = analyze_cmd.analyze(bytes)?;
@@ -729,9 +727,8 @@ fn main() -> Result<()> {
             // Create and execute convert command
             let convert_cmd = binfiddle::ConvertCommand::new(config);
 
-            // Read all data for conversion
-            let chunk = binary_data.read_range(0, None)?;
-            let bytes = chunk.get_bytes();
+            // Convert directly against the backing bytes without copying the whole file.
+            let bytes = binary_data.as_bytes();
 
             // Perform conversion
             let converted = convert_cmd.convert(bytes)?;
@@ -937,18 +934,18 @@ fn main() -> Result<()> {
             binfiddle::process_memory::write_process_memory(
                 pid,
                 address,
-                binary_data.read_range(0, None)?.get_bytes(),
+                binary_data.as_bytes(),
                 cli.force_writable,
             )?;
         } else if cli.in_file {
             if let Some(path) = &cli.input {
-                std::fs::write(path, binary_data.read_range(0, None)?.get_bytes())?;
+                std::fs::write(path, binary_data.as_bytes())?;
             }
         } else if let Some(output) = &cli.output {
             if output == "-" {
-                io::stdout().write_all(binary_data.read_range(0, None)?.get_bytes())?;
+                io::stdout().write_all(binary_data.as_bytes())?;
             } else {
-                std::fs::write(output, binary_data.read_range(0, None)?.get_bytes())?;
+                std::fs::write(output, binary_data.as_bytes())?;
             }
         } else if !cli.silent {
             eprintln!("Warning: Changes were made but no output specified");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 /// src/main.rs
 use binfiddle::utils::parsing::{parse_search_pattern, validate_search_pattern};
+use binfiddle::utils::progress::{Progress, ProgressReader};
 use binfiddle::{BinaryData, BinarySource, BinfiddleError, Result, SearchConfig};
 use clap::{Parser, Subcommand};
 use std::io::{self, Read, Write};
@@ -440,10 +441,17 @@ fn main() -> Result<()> {
         };
         let search_cmd = binfiddle::SearchCommand::new(config);
 
-        let input: Box<dyn Read> = match cli.input.as_deref() {
-            Some("-") | None => Box::new(io::stdin()),
-            Some(path) => Box::new(std::fs::File::open(path)?),
+        let (input, total): (Box<dyn Read>, Option<u64>) = match cli.input.as_deref() {
+            Some("-") | None => (Box::new(io::stdin()), None),
+            Some(path) => {
+                let file = std::fs::File::open(path)?;
+                let total = file.metadata().ok().map(|m| m.len());
+                (Box::new(file), total)
+            }
         };
+
+        let progress = Progress::new(total, "Searching", cli.silent);
+        let input = ProgressReader::new(input, progress);
 
         let matches = search_cmd.search_stream(input, block_size)?;
 
@@ -493,10 +501,17 @@ fn main() -> Result<()> {
             };
             let analyze_cmd = binfiddle::AnalyzeCommand::new(config);
 
-            let input: Box<dyn Read> = match cli.input.as_deref() {
-                Some("-") | None => Box::new(io::stdin()),
-                Some(path) => Box::new(std::fs::File::open(path)?),
+            let (input, total): (Box<dyn Read>, Option<u64>) = match cli.input.as_deref() {
+                Some("-") | None => (Box::new(io::stdin()), None),
+                Some(path) => {
+                    let file = std::fs::File::open(path)?;
+                    let total = file.metadata().ok().map(|m| m.len());
+                    (Box::new(file), total)
+                }
             };
+
+            let progress = Progress::new(total, "Analyzing", cli.silent);
+            let input = ProgressReader::new(input, progress);
 
             let output = analyze_cmd.analyze_stream(input)?;
             println!("{}", output);
@@ -531,10 +546,17 @@ fn main() -> Result<()> {
             let hash_cmd = binfiddle::HashCommand::new(config);
 
             let read_chunk_size = parse_byte_size(read_block_size)?;
-            let input: Box<dyn Read> = match cli.input.as_deref() {
-                Some("-") | None => Box::new(io::stdin()),
-                Some(path) => Box::new(std::fs::File::open(path)?),
+            let (input, total): (Box<dyn Read>, Option<u64>) = match cli.input.as_deref() {
+                Some("-") | None => (Box::new(io::stdin()), None),
+                Some(path) => {
+                    let file = std::fs::File::open(path)?;
+                    let total = file.metadata().ok().map(|m| m.len());
+                    (Box::new(file), total)
+                }
             };
+
+            let progress = Progress::new(total, "Hashing", cli.silent);
+            let input = ProgressReader::new(input, progress);
 
             let output = hash_cmd.compute_stream(input, read_chunk_size)?;
             println!("{}", output);
@@ -778,8 +800,18 @@ fn main() -> Result<()> {
             // Search directly against the backing bytes without copying the whole file.
             let bytes = binary_data.as_bytes();
 
+            // Show a spinner for full scans, which can be slow on large files.
+            let progress = if *all {
+                Some(Progress::new(None, "Searching", cli.silent))
+            } else {
+                None
+            };
+
             // Perform search
             let matches = search_cmd.search(bytes)?;
+            if let Some(progress) = progress {
+                progress.finish();
+            }
 
             // Report results
             if matches.is_empty() {
@@ -823,13 +855,26 @@ fn main() -> Result<()> {
             };
 
             // Create and execute analyze command
-            let analyze_cmd = binfiddle::AnalyzeCommand::new(config);
+            let analyze_cmd = binfiddle::AnalyzeCommand::new(config.clone());
 
             // Analyze directly against the backing bytes without copying the whole file.
             let bytes = binary_data.as_bytes();
 
+            // Show progress for block-based analysis; use a spinner otherwise.
+            let output = if config.block_size > 0 && config.range.is_none() {
+                let total = Some(bytes.len() as u64);
+                let progress = Progress::new(total, "Analyzing", cli.silent);
+                let cursor = std::io::Cursor::new(bytes);
+                let reader = ProgressReader::new(cursor, progress);
+                analyze_cmd.analyze_stream(reader)?
+            } else {
+                let progress = Progress::new(None, "Analyzing", cli.silent);
+                let result = analyze_cmd.analyze(bytes)?;
+                progress.finish();
+                result
+            };
+
             // Perform analysis and print results
-            let output = analyze_cmd.analyze(bytes)?;
             println!("{}", output);
 
             false // Analyze doesn't modify data
@@ -852,9 +897,14 @@ fn main() -> Result<()> {
             };
             let hash_cmd = binfiddle::HashCommand::new(config);
 
-            // Hash directly against the backing bytes without copying the whole file.
+            // Hash directly against the backing bytes without copying the whole file,
+            // showing a progress bar for large inputs.
             let bytes = binary_data.as_bytes();
-            let output = hash_cmd.compute(bytes)?;
+            let total = Some(bytes.len() as u64);
+            let progress = Progress::new(total, "Hashing", cli.silent);
+            let cursor = std::io::Cursor::new(bytes);
+            let reader = ProgressReader::new(cursor, progress);
+            let output = hash_cmd.compute_stream(reader, 1024 * 1024)?;
             println!("{}", output);
 
             false // Hash doesn't modify data
@@ -984,8 +1034,12 @@ fn main() -> Result<()> {
             // Convert directly against the backing bytes without copying the whole file.
             let bytes = binary_data.as_bytes();
 
+            // Show a spinner because conversion can take a while on large files.
+            let progress = Progress::new(None, "Converting", cli.silent);
+
             // Perform conversion
             let converted = convert_cmd.convert(bytes)?;
+            progress.finish();
 
             // Output the converted data
             // Convert always produces output (doesn't modify in-place via BinaryData)

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,6 +142,10 @@ enum Commands {
         /// Read chunk size when streaming (supports K/M/G suffixes, default 1M)
         #[arg(long, default_value = "1M")]
         read_block_size: String,
+
+        /// Verify checksums from a file (md5sum/sha256sum format)
+        #[arg(long, value_name = "CHECKSUM_FILE")]
+        check: Option<String>,
     },
 
     /// Search for patterns in binary data
@@ -507,6 +511,7 @@ fn main() -> Result<()> {
         block_size,
         stream,
         read_block_size,
+        check: _,
     } = command
     {
         if *stream {
@@ -537,13 +542,47 @@ fn main() -> Result<()> {
         }
     }
 
+    // Handle checksum verification before loading binary data.
+    if let Commands::Hash {
+        algorithm,
+        output_format,
+        block_size,
+        check: Some(check_file),
+        read_block_size,
+        ..
+    } = command
+    {
+        if *block_size != 0 {
+            return Err(BinfiddleError::InvalidInput(
+                "--check requires --block-size 0 (whole file)".to_string(),
+            ));
+        }
+
+        let algorithm = algorithm.parse::<binfiddle::HashAlgorithm>()?;
+        let output_format = output_format.parse::<binfiddle::HashOutputFormat>()?;
+        let config = binfiddle::HashConfig {
+            algorithm,
+            output_format,
+            block_size: 0,
+        };
+        let hash_cmd = binfiddle::HashCommand::new(config);
+
+        let read_chunk_size = parse_byte_size(read_block_size)?;
+        let (report, ok) = hash_cmd.check(check_file.as_ref(), read_chunk_size)?;
+        println!("{}", report);
+        if !ok {
+            return Err(BinfiddleError::ChecksumVerificationFailed);
+        }
+        return Ok(());
+    }
+
     // Check if this command needs binary_data loaded
     let needs_input = matches!(
         command,
         Commands::Read { .. }
             | Commands::Write { .. }
             | Commands::Edit { .. }
-            | Commands::Hash { .. }
+            | Commands::Hash { check: None, .. }
             | Commands::Search { .. }
             | Commands::Convert { .. }
             | Commands::Analyze { .. }
@@ -801,6 +840,7 @@ fn main() -> Result<()> {
             block_size,
             stream: _,
             read_block_size: _,
+            check: _,
         } => {
             let algorithm = algorithm.parse::<binfiddle::HashAlgorithm>()?;
             let output_format = output_format.parse::<binfiddle::HashOutputFormat>()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,9 +180,9 @@ enum Commands {
         #[arg(value_parser = ["entropy", "histogram", "hist", "ic", "ioc"])]
         analysis_type: String,
 
-        /// Block size for block-based analysis (0 = entire file)
+        /// Block size for block-based analysis (0 = entire file, supports K/M/G suffixes)
         #[arg(long, default_value = "256")]
-        block_size: usize,
+        block_size: String,
 
         /// Output format: human, csv, json
         #[arg(long, default_value = "human", value_parser = ["human", "csv", "json"])]
@@ -449,6 +449,49 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    // Handle streaming analyze before loading binary data.
+    if let Commands::Analyze {
+        analysis_type,
+        block_size,
+        output_format,
+        range,
+    } = command
+    {
+        let block_size = parse_byte_size(block_size)?;
+        if block_size > 0 {
+            if source_is_process_memory {
+                return Err(BinfiddleError::InvalidInput(
+                    "--block-size streaming analyze cannot be used with --process-self or --pid"
+                        .to_string(),
+                ));
+            }
+            if range.is_some() {
+                return Err(BinfiddleError::InvalidInput(
+                    "--range is not supported with --block-size streaming analyze".to_string(),
+                ));
+            }
+
+            let analysis = analysis_type.parse::<binfiddle::AnalysisType>()?;
+            let format = output_format.parse::<binfiddle::AnalyzeOutputFormat>()?;
+            let config = binfiddle::AnalyzeConfig {
+                analysis_type: analysis,
+                block_size,
+                format,
+                range: None,
+            };
+            let analyze_cmd = binfiddle::AnalyzeCommand::new(config);
+
+            let input: Box<dyn Read> = match cli.input.as_deref() {
+                Some("-") | None => Box::new(io::stdin()),
+                Some(path) => Box::new(std::fs::File::open(path)?),
+            };
+
+            let output = analyze_cmd.analyze_stream(input)?;
+            println!("{}", output);
+            return Ok(());
+        }
+    }
+
     // Check if this command needs binary_data loaded
     let needs_input = matches!(
         command,
@@ -690,7 +733,7 @@ fn main() -> Result<()> {
             // Build analyze configuration
             let config = binfiddle::AnalyzeConfig {
                 analysis_type: analysis,
-                block_size: *block_size,
+                block_size: parse_byte_size(block_size)?,
                 format,
                 range: range_bounds,
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 /// src/main.rs
 use binfiddle::utils::parsing::{parse_search_pattern, validate_search_pattern};
-use binfiddle::{BinaryData, BinarySource, Result, SearchConfig};
+use binfiddle::{BinaryData, BinarySource, BinfiddleError, Result, SearchConfig};
 use clap::{Parser, Subcommand};
 use std::io::{self, Read, Write};
 
@@ -12,8 +12,20 @@ struct Cli {
     command: Commands,
 
     /// Input file (use '-' for stdin)
-    #[arg(short, long)]
+    #[arg(short, long, group = "source")]
     input: Option<String>,
+
+    /// Read from current process memory via /proc/self/mem (Linux only)
+    #[arg(long, group = "source", requires = "address", requires = "size")]
+    process_self: bool,
+
+    /// Base address to read from when using --process-self (hex or decimal)
+    #[arg(long, requires = "process_self")]
+    address: Option<String>,
+
+    /// Number of bytes to read when using --process-self (hex or decimal)
+    #[arg(long, requires = "process_self")]
+    size: Option<String>,
 
     /// Modify file directly (requires input file)
     #[arg(long, requires = "input", conflicts_with = "output")]
@@ -247,6 +259,11 @@ fn main() -> Result<()> {
 
     // Handle chain command early, before normal input loading.
     if let Commands::Chain { step } = &cli.command {
+        if cli.process_self {
+            return Err(BinfiddleError::InvalidInput(
+                "--process-self cannot be used with chain".to_string(),
+            ));
+        }
         return binfiddle::ChainExecutor::execute(
             step,
             cli.input.as_deref(),
@@ -268,20 +285,38 @@ fn main() -> Result<()> {
 
     // Load data only for commands that need it
     let mut binary_data = if needs_input {
-        match cli.input.as_deref() {
-            Some("-") | None => {
-                let mut data = Vec::new();
-                io::stdin().read_to_end(&mut data)?;
-                BinaryData::new(BinarySource::RawData(data), cli.chunk_size, cli.width)?
-            }
-            Some(path) => {
-                BinaryData::new(BinarySource::File(path.into()), cli.chunk_size, cli.width)?
+        if cli.process_self {
+            let address = parse_address_or_size(
+                cli.address
+                    .as_deref()
+                    .expect("clap ensures address is present"),
+            )?;
+            let size =
+                parse_address_or_size(cli.size.as_deref().expect("clap ensures size is present"))?;
+            BinaryData::new(
+                BinarySource::ProcessSelf { address, size },
+                cli.chunk_size,
+                cli.width,
+            )?
+        } else {
+            match cli.input.as_deref() {
+                Some("-") | None => {
+                    let mut data = Vec::new();
+                    io::stdin().read_to_end(&mut data)?;
+                    BinaryData::new(BinarySource::RawData(data), cli.chunk_size, cli.width)?
+                }
+                Some(path) => {
+                    BinaryData::new(BinarySource::File(path.into()), cli.chunk_size, cli.width)?
+                }
             }
         }
     } else {
         // Create a dummy BinaryData for commands that don't need it
         BinaryData::new(BinarySource::RawData(Vec::new()), cli.chunk_size, cli.width)?
     };
+
+    // Remember whether the source is process memory so we can reject writes later.
+    let source_is_process_self = cli.process_self;
 
     // Execute command
     let changes_made = match &cli.command {
@@ -791,6 +826,13 @@ fn main() -> Result<()> {
 
     // Handle output
     if changes_made {
+        if source_is_process_self {
+            return Err(BinfiddleError::UnsupportedOperation(
+                "Writing to process memory is not supported in this version. \
+                 Use --output to write the result to a file."
+                    .to_string(),
+            ));
+        }
         if cli.in_file {
             if let Some(path) = &cli.input {
                 std::fs::write(path, binary_data.read_range(0, None)?.get_bytes())?;
@@ -808,4 +850,22 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Parse an address or size string that may be decimal or hex (with optional `0x` prefix).
+fn parse_address_or_size(value: &str) -> Result<u64> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(BinfiddleError::InvalidInput(
+            "Address/size cannot be empty".to_string(),
+        ));
+    }
+    let (radix, stripped) = if let Some(stripped) = value.strip_prefix("0x") {
+        (16, stripped)
+    } else {
+        (10, value)
+    };
+    u64::from_str_radix(stripped, radix).map_err(|e| {
+        BinfiddleError::InvalidInput(format!("Invalid address/size '{}': {}", value, e))
+    })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,20 @@ enum Commands {
         data: Option<String>,
     },
 
+    /// Compute a hash digest of the binary data
+    Hash {
+        /// Hash algorithm: md5, sha256, blake3, crc32
+        algorithm: String,
+
+        /// Output format: hex
+        #[arg(long, default_value = "hex", value_parser = ["hex"])]
+        output_format: String,
+
+        /// Block size for block-based hashing (0 = whole file)
+        #[arg(long, default_value = "0")]
+        block_size: usize,
+    },
+
     /// Search for patterns in binary data
     Search {
         /// Pattern to search for (interpreted per --input-format)
@@ -154,6 +168,10 @@ enum Commands {
         /// Colorize output (always, auto, never)
         #[arg(long, default_value = "auto", value_parser = ["always", "auto", "never"])]
         color: String,
+
+        /// Stream input in blocks of this size (e.g., 64M, 1G, 256K)
+        #[arg(long)]
+        block_size: Option<String>,
     },
 
     /// Analyze binary data (entropy, histogram, index of coincidence)
@@ -356,12 +374,88 @@ fn main() -> Result<()> {
         binfiddle::process_memory::FillMode::Error
     };
 
+    // Handle streaming search before loading binary data, so huge inputs are
+    // not memory-mapped or copied in full.
+    if let Commands::Search {
+        pattern,
+        input_format,
+        all,
+        count,
+        offsets_only,
+        context,
+        no_overlap,
+        color,
+        block_size: Some(block_size_str),
+    } = command
+    {
+        if source_is_process_memory {
+            return Err(BinfiddleError::InvalidInput(
+                "--block-size cannot be used with --process-self or --pid".to_string(),
+            ));
+        }
+        if *context > 0 {
+            return Err(BinfiddleError::InvalidInput(
+                "--context is not supported with --block-size streaming search".to_string(),
+            ));
+        }
+
+        let block_size = parse_byte_size(block_size_str)?;
+
+        if !cli.silent {
+            let warnings = validate_search_pattern(pattern, input_format);
+            for warning in warnings {
+                eprintln!("{}\n", warning);
+            }
+        }
+
+        let search_pattern = parse_search_pattern(pattern, input_format)?;
+        let color_mode = match color.as_str() {
+            "always" => binfiddle::ColorMode::Always,
+            "never" => binfiddle::ColorMode::Never,
+            _ => binfiddle::ColorMode::Auto,
+        };
+
+        let config = SearchConfig {
+            pattern: search_pattern,
+            format: cli.format.clone(),
+            chunk_size: cli.chunk_size,
+            find_all: *all,
+            count_only: *count,
+            offsets_only: *offsets_only,
+            context: *context,
+            no_overlap: *no_overlap,
+            color: color_mode,
+        };
+        let search_cmd = binfiddle::SearchCommand::new(config);
+
+        let input: Box<dyn Read> = match cli.input.as_deref() {
+            Some("-") | None => Box::new(io::stdin()),
+            Some(path) => Box::new(std::fs::File::open(path)?),
+        };
+
+        let matches = search_cmd.search_stream(input, block_size)?;
+
+        if matches.is_empty() {
+            if !cli.silent {
+                eprintln!("No matches found");
+            }
+        } else {
+            let output = search_cmd.format_results(&[], &matches)?;
+            if !output.is_empty() {
+                println!("{}", output);
+            }
+        }
+
+        return Ok(());
+    }
+
     // Check if this command needs binary_data loaded
     let needs_input = matches!(
         command,
         Commands::Read { .. }
             | Commands::Write { .. }
             | Commands::Edit { .. }
+            | Commands::Hash { .. }
             | Commands::Search { .. }
             | Commands::Convert { .. }
             | Commands::Analyze { .. }
@@ -395,7 +489,14 @@ fn main() -> Result<()> {
                     BinaryData::new(BinarySource::RawData(data), cli.chunk_size, cli.width)?
                 }
                 Some(path) => {
-                    BinaryData::new(BinarySource::File(path.into()), cli.chunk_size, cli.width)?
+                    let writable_in_place =
+                        matches!(command, Commands::Write { .. }) && cli.in_file;
+                    let source = if writable_in_place {
+                        BinarySource::WritableFile(path.into())
+                    } else {
+                        BinarySource::File(path.into())
+                    };
+                    BinaryData::new(source, cli.chunk_size, cli.width)?
                 }
             }
         }
@@ -511,6 +612,7 @@ fn main() -> Result<()> {
             context,
             no_overlap,
             color,
+            block_size: _,
         } => {
             // Validate pattern and show warnings if format might be incorrect
             let warnings = validate_search_pattern(pattern, input_format);
@@ -604,6 +706,28 @@ fn main() -> Result<()> {
             println!("{}", output);
 
             false // Analyze doesn't modify data
+        }
+        Commands::Hash {
+            algorithm,
+            output_format,
+            block_size,
+        } => {
+            let algorithm = algorithm.parse::<binfiddle::HashAlgorithm>()?;
+            let output_format = output_format.parse::<binfiddle::HashOutputFormat>()?;
+
+            let config = binfiddle::HashConfig {
+                algorithm,
+                output_format,
+                block_size: *block_size,
+            };
+            let hash_cmd = binfiddle::HashCommand::new(config);
+
+            // Hash directly against the backing bytes without copying the whole file.
+            let bytes = binary_data.as_bytes();
+            let output = hash_cmd.compute(bytes)?;
+            println!("{}", output);
+
+            false // Hash doesn't modify data
         }
         Commands::Diff {
             file1,
@@ -939,7 +1063,10 @@ fn main() -> Result<()> {
             )?;
         } else if cli.in_file {
             if let Some(path) = &cli.input {
-                std::fs::write(path, binary_data.as_bytes())?;
+                // WritableFile has already flushed changes directly to disk.
+                if !matches!(binary_data.source(), BinarySource::WritableFile(_)) {
+                    std::fs::write(path, binary_data.as_bytes())?;
+                }
             }
         } else if let Some(output) = &cli.output {
             if output == "-" {
@@ -972,4 +1099,43 @@ fn parse_address_or_size(value: &str) -> Result<u64> {
     u64::from_str_radix(stripped, radix).map_err(|e| {
         BinfiddleError::InvalidInput(format!("Invalid address/size '{}': {}", value, e))
     })
+}
+
+/// Parse a human-readable byte size such as `64K`, `128M`, or `2G`.
+fn parse_byte_size(value: &str) -> Result<usize> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(BinfiddleError::InvalidInput(
+            "Block size cannot be empty".to_string(),
+        ));
+    }
+
+    let last = value.chars().last().unwrap();
+    let multiplier = match last.to_ascii_uppercase() {
+        'B' => 1usize,
+        'K' => 1024usize,
+        'M' => 1024 * 1024,
+        'G' => 1024 * 1024 * 1024,
+        _ => {
+            return value.parse::<usize>().map_err(|e| {
+                BinfiddleError::InvalidInput(format!("Invalid block size '{}': {}", value, e))
+            });
+        }
+    };
+
+    let number_part = &value[..value.len() - 1];
+    if number_part.is_empty() {
+        return Err(BinfiddleError::InvalidInput(format!(
+            "Invalid block size '{}': missing number",
+            value
+        )));
+    }
+
+    let number = number_part.parse::<usize>().map_err(|e| {
+        BinfiddleError::InvalidInput(format!("Invalid block size '{}': {}", value, e))
+    })?;
+
+    number
+        .checked_mul(multiplier)
+        .ok_or_else(|| BinfiddleError::InvalidInput(format!("Block size '{}' is too large", value)))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,10 @@ struct Cli {
     #[arg(long)]
     allow_write: bool,
 
+    /// Temporarily make read-only process-memory pages writable before writing
+    #[arg(long, requires = "allow_write")]
+    force_writable: bool,
+
     /// Base address to read from when using --process-self or --pid (hex or decimal)
     #[arg(long)]
     address: Option<String>,
@@ -885,6 +889,7 @@ fn main() -> Result<()> {
                 pid,
                 address,
                 binary_data.read_range(0, None)?.get_bytes(),
+                cli.force_writable,
             )?;
         } else if cli.in_file {
             if let Some(path) = &cli.input {

--- a/src/main.rs
+++ b/src/main.rs
@@ -434,10 +434,10 @@ fn main() -> Result<()> {
             range,
         } => {
             // Parse analysis type
-            let analysis = binfiddle::AnalysisType::from_str(analysis_type)?;
+            let analysis = analysis_type.parse::<binfiddle::AnalysisType>()?;
 
             // Parse output format
-            let format = binfiddle::AnalyzeOutputFormat::from_str(output_format)?;
+            let format = output_format.parse::<binfiddle::AnalyzeOutputFormat>()?;
 
             // Parse optional range
             let range_bounds = if let Some(range_str) = range {
@@ -511,7 +511,7 @@ fn main() -> Result<()> {
                 let max_size = data1.len().max(data2.len());
                 binfiddle::DiffFormat::auto_select(differences.len(), max_size)
             } else {
-                binfiddle::DiffFormat::from_str(diff_format)?
+                diff_format.parse::<binfiddle::DiffFormat>()?
             };
 
             // Warn about large diffs BEFORE outputting
@@ -575,9 +575,9 @@ fn main() -> Result<()> {
             // Parse configuration options
             let from_encoding = binfiddle::parse_encoding(from)?;
             let to_encoding = binfiddle::parse_encoding(to)?;
-            let newline_mode = binfiddle::NewlineMode::from_str(newlines)?;
-            let bom_mode = binfiddle::BomMode::from_str(bom)?;
-            let error_mode = binfiddle::ErrorMode::from_str(on_error)?;
+            let newline_mode = newlines.parse::<binfiddle::NewlineMode>()?;
+            let bom_mode = bom.parse::<binfiddle::BomMode>()?;
+            let error_mode = on_error.parse::<binfiddle::ErrorMode>()?;
 
             // Build configuration
             let config = binfiddle::ConvertConfig {
@@ -718,7 +718,7 @@ fn main() -> Result<()> {
 
             // Build configuration
             let config = binfiddle::StructConfig {
-                format: binfiddle::StructOutputFormat::from_str(output_format)?,
+                format: output_format.parse::<binfiddle::StructOutputFormat>()?,
                 get_fields: get.clone(),
                 list_fields: *list_fields,
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,14 @@ struct Cli {
     #[arg(long, requires = "allow_write")]
     force_writable: bool,
 
+    /// Replace inaccessible process-memory pages with zeros instead of failing
+    #[arg(long, conflicts_with = "skip_inaccessible")]
+    zero_fill_inaccessible: bool,
+
+    /// Skip inaccessible process-memory pages instead of failing (read only)
+    #[arg(long, conflicts_with = "zero_fill_inaccessible")]
+    skip_inaccessible: bool,
+
     /// Base address to read from when using --process-self or --pid (hex or decimal)
     #[arg(long)]
     address: Option<String>,
@@ -318,6 +326,36 @@ fn main() -> Result<()> {
         }
     }
 
+    let fill_mode = if cli.zero_fill_inaccessible {
+        if !source_is_process_memory {
+            return Err(BinfiddleError::InvalidInput(
+                "--zero-fill-inaccessible can only be used with --process-self or --pid"
+                    .to_string(),
+            ));
+        }
+        if !matches!(command, Commands::Read { .. } | Commands::Search { .. }) {
+            return Err(BinfiddleError::InvalidInput(
+                "--zero-fill-inaccessible is only supported with read and search commands"
+                    .to_string(),
+            ));
+        }
+        binfiddle::process_memory::FillMode::ZeroFill
+    } else if cli.skip_inaccessible {
+        if !source_is_process_memory {
+            return Err(BinfiddleError::InvalidInput(
+                "--skip-inaccessible can only be used with --process-self or --pid".to_string(),
+            ));
+        }
+        if !matches!(command, Commands::Read { .. }) {
+            return Err(BinfiddleError::InvalidInput(
+                "--skip-inaccessible is only supported with the read command".to_string(),
+            ));
+        }
+        binfiddle::process_memory::FillMode::Skip
+    } else {
+        binfiddle::process_memory::FillMode::Error
+    };
+
     // Check if this command needs binary_data loaded
     let needs_input = matches!(
         command,
@@ -335,9 +373,18 @@ fn main() -> Result<()> {
             let address = parse_address_or_size(cli.address.as_deref().unwrap())?;
             let size = parse_address_or_size(cli.size.as_deref().unwrap())?;
             let source = if pid == 0 {
-                BinarySource::ProcessSelf { address, size }
+                BinarySource::ProcessSelf {
+                    address,
+                    size,
+                    fill_mode,
+                }
             } else {
-                BinarySource::Process { pid, address, size }
+                BinarySource::Process {
+                    pid,
+                    address,
+                    size,
+                    fill_mode,
+                }
             };
             BinaryData::new(source, cli.chunk_size, cli.width)?
         } else {
@@ -873,8 +920,10 @@ fn main() -> Result<()> {
             }
 
             let (pid, address, original_size) = match binary_data.source() {
-                BinarySource::ProcessSelf { address, size } => (0, *address, *size as usize),
-                BinarySource::Process { pid, address, size } => (*pid, *address, *size as usize),
+                BinarySource::ProcessSelf { address, size, .. } => (0, *address, *size as usize),
+                BinarySource::Process {
+                    pid, address, size, ..
+                } => (*pid, *address, *size as usize),
                 _ => unreachable!(),
             };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,10 +233,27 @@ enum Commands {
         #[arg(long, default_value = "human", value_parser = ["human", "json", "yaml"])]
         output_format: String,
     },
+
+    /// Execute multiple binfiddle commands in sequence
+    Chain {
+        /// Command step to execute (can be repeated)
+        #[arg(long, required = true)]
+        step: Vec<String>,
+    },
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    // Handle chain command early, before normal input loading.
+    if let Commands::Chain { step } = &cli.command {
+        return binfiddle::ChainExecutor::execute(
+            step,
+            cli.input.as_deref(),
+            cli.output.as_deref(),
+            cli.silent,
+        );
+    }
 
     // Check if this command needs binary_data loaded
     let needs_input = matches!(
@@ -765,6 +782,10 @@ fn main() -> Result<()> {
             }
 
             false // Struct handles its own output
+        }
+        Commands::Chain { .. } => {
+            // Chain is handled before this match.
+            unreachable!()
         }
     };
 

--- a/src/process_memory.rs
+++ b/src/process_memory.rs
@@ -1,7 +1,8 @@
 //! Process memory access helpers (Linux-only).
 //!
-//! This module provides a minimal, read-mostly interface to `/proc/<pid>/mem`
-//! and `/proc/<pid>/maps`. It is intentionally scoped to Linux and focuses on
+//! This module provides a minimal interface to process memory via
+//! `/proc/<pid>/maps`, `/proc/self/mem`, and `process_vm_readv` /
+//! `process_vm_writev`. It is intentionally scoped to Linux and focuses on
 //! same-user process inspection.
 
 use crate::{BinfiddleError, Result};
@@ -38,18 +39,6 @@ impl MemoryRegion {
     }
 }
 
-/// Returns the path to a process's `/proc/<pid>/mem` file.
-///
-/// Uses `/proc/self/mem` when the pid is the current process so tests and
-/// self-introspection work without caring about the actual pid.
-fn proc_mem_path(pid: u32) -> PathBuf {
-    if pid == 0 || pid == std::process::id() {
-        PathBuf::from("/proc/self/mem")
-    } else {
-        PathBuf::from(format!("/proc/{}/mem", pid))
-    }
-}
-
 /// Returns the path to a process's `/proc/<pid>/maps` file.
 fn proc_maps_path(pid: u32) -> PathBuf {
     if pid == 0 || pid == std::process::id() {
@@ -66,22 +55,28 @@ pub fn read_process_memory(pid: u32, address: u64, size: u64) -> Result<Vec<u8>>
             "Requested size exceeds addressable memory".to_string(),
         ));
     }
+
+    if pid == 0 || pid == std::process::id() {
+        read_self_memory(address, size)
+    } else {
+        read_cross_process_memory(pid, address, size)
+    }
+}
+
+fn read_self_memory(address: u64, size: u64) -> Result<Vec<u8>> {
     let size = size as usize;
 
-    let mut file = File::open(proc_mem_path(pid)).map_err(|e| {
+    let mut file = File::open("/proc/self/mem").map_err(|e| {
         BinfiddleError::ProcessMemoryError(format!(
-            "Failed to open /proc/{}/mem: {}",
-            pid_label(pid),
+            "Failed to open current process memory for reading: {}",
             e
         ))
     })?;
 
     file.seek(SeekFrom::Start(address)).map_err(|e| {
         BinfiddleError::ProcessMemoryError(format!(
-            "Failed to seek to address 0x{:x} in process {}: {}",
-            address,
-            pid_label(pid),
-            e
+            "Failed to seek to address 0x{:x} in current process memory: {}",
+            address, e
         ))
     })?;
 
@@ -92,23 +87,58 @@ pub fn read_process_memory(pid: u32, address: u64, size: u64) -> Result<Vec<u8>>
         match file.read(&mut buffer[total_read..]) {
             Ok(0) => {
                 return Err(BinfiddleError::ProcessMemoryError(format!(
-                    "Short read while reading process {} memory at 0x{:x}: expected {}, got {}",
-                    pid_label(pid),
-                    address,
-                    size,
-                    total_read
+                    "Short read while reading current process memory at 0x{:x}: expected {}, got {}",
+                    address, size, total_read
                 )));
             }
             Ok(n) => total_read += n,
             Err(e) => {
                 return Err(BinfiddleError::ProcessMemoryError(format!(
-                    "Failed to read process {} memory at 0x{:x}: {}",
-                    pid_label(pid),
+                    "Failed to read current process memory at 0x{:x}: {}",
                     address + total_read as u64,
                     e
                 )));
             }
         }
+    }
+
+    Ok(buffer)
+}
+
+fn read_cross_process_memory(pid: u32, address: u64, size: u64) -> Result<Vec<u8>> {
+    let size = size as usize;
+    let mut buffer = vec![0u8; size];
+    let mut total_read = 0usize;
+
+    while total_read < size {
+        let local_iov = libc::iovec {
+            iov_base: buffer[total_read..].as_mut_ptr() as *mut libc::c_void,
+            iov_len: size - total_read,
+        };
+        let remote_iov = libc::iovec {
+            iov_base: (address + total_read as u64) as *mut libc::c_void,
+            iov_len: size - total_read,
+        };
+
+        let ret =
+            unsafe { libc::process_vm_readv(pid as libc::pid_t, &local_iov, 1, &remote_iov, 1, 0) };
+
+        if ret < 0 {
+            let err = std::io::Error::last_os_error();
+            return Err(BinfiddleError::ProcessMemoryError(format!(
+                "process_vm_readv failed for pid {}: {} (ensure ptrace access is permitted)",
+                pid, err
+            )));
+        }
+
+        if ret == 0 {
+            return Err(BinfiddleError::ProcessMemoryError(format!(
+                "Short read while reading process {} memory at 0x{:x}: expected {}, got {}",
+                pid, address, size, total_read
+            )));
+        }
+
+        total_read += ret as usize;
     }
 
     Ok(buffer)
@@ -132,7 +162,7 @@ pub fn write_process_memory(
         if force_writable {
             force_write_self_memory(address, data)
         } else {
-            write_self_memory(address, data)
+            write_self_memory_checked(address, data)
         }
     } else {
         write_cross_process_memory(pid, address, data, force_writable)
@@ -168,6 +198,26 @@ fn write_self_memory(address: u64, data: &[u8]) -> Result<()> {
     Ok(())
 }
 
+fn write_self_memory_checked(address: u64, data: &[u8]) -> Result<()> {
+    let regions = parse_maps(0)?;
+    let region = find_region(&regions, address).ok_or_else(|| {
+        BinfiddleError::ProcessMemoryError(format!(
+            "Address 0x{:x} is not in any mapped region of the current process",
+            address
+        ))
+    })?;
+
+    if !region.is_writable() {
+        return Err(BinfiddleError::ProcessMemoryError(format!(
+            "Memory region 0x{:x}-0x{:x} in the current process is not writable (use --force-writable to override)",
+            region.start, region.end
+        )));
+    }
+
+    check_region_bounds(region, address, data.len())?;
+    write_self_memory(address, data)
+}
+
 fn force_write_self_memory(address: u64, data: &[u8]) -> Result<()> {
     let regions = parse_maps(0)?;
     let region = find_region(&regions, address).ok_or_else(|| {
@@ -177,6 +227,8 @@ fn force_write_self_memory(address: u64, data: &[u8]) -> Result<()> {
         ))
     })?;
 
+    check_region_bounds(region, address, data.len())?;
+
     let original_prot = prot_from_perms(&region.perms);
 
     let page_size = page_size();
@@ -184,30 +236,12 @@ fn force_write_self_memory(address: u64, data: &[u8]) -> Result<()> {
     let protect_end = (region.end + page_size - 1) & !(page_size - 1);
     let protect_len = protect_end - protect_start;
 
-    let result = unsafe {
-        if libc::mprotect(
-            protect_start as *mut libc::c_void,
-            protect_len as usize,
-            libc::PROT_READ | libc::PROT_WRITE,
-        ) != 0
-        {
-            Err(BinfiddleError::ProcessMemoryError(format!(
-                "mprotect failed for region 0x{:x}-0x{:x}: {}",
-                protect_start,
-                protect_end,
-                std::io::Error::last_os_error()
-            )))
-        } else {
-            write_self_memory(address, data)
-        }
-    };
+    let mut guard = MprotectGuard::make_writable(protect_start, protect_len, original_prot)?;
+    let result = write_self_memory(address, data);
 
-    unsafe {
-        let _ = libc::mprotect(
-            protect_start as *mut libc::c_void,
-            protect_len as usize,
-            original_prot,
-        );
+    // If the write succeeded, a restore failure must be reported to the caller.
+    if result.is_ok() {
+        guard.restore()?;
     }
 
     result
@@ -233,6 +267,8 @@ fn write_cross_process_memory(
             region.start, region.end, pid
         )));
     }
+
+    check_region_bounds(region, address, data.len())?;
 
     if force_writable {
         force_write_cross_process_memory(pid, address, data, region)?;
@@ -273,6 +309,52 @@ fn process_vm_writev_data(pid: u32, address: u64, data: &[u8]) -> Result<()> {
     Ok(())
 }
 
+/// RAII guard that temporarily makes a remote memory region writable via
+/// ptrace-injected `mprotect` and restores the original protection on drop or
+/// explicit restore.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+struct PtraceMprotectGuard<'a> {
+    target: nix::unistd::Pid,
+    region: &'a MemoryRegion,
+    original_prot: libc::c_int,
+    restored: bool,
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+impl<'a> PtraceMprotectGuard<'a> {
+    fn make_writable(
+        target: nix::unistd::Pid,
+        region: &'a MemoryRegion,
+        original_prot: libc::c_int,
+    ) -> Result<Self> {
+        ptrace_inject_mprotect(target, region, libc::PROT_READ | libc::PROT_WRITE)?;
+        Ok(Self {
+            target,
+            region,
+            original_prot,
+            restored: false,
+        })
+    }
+
+    fn restore(&mut self) -> Result<()> {
+        if self.restored {
+            return Ok(());
+        }
+        ptrace_inject_mprotect(self.target, self.region, self.original_prot)?;
+        self.restored = true;
+        Ok(())
+    }
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+impl<'a> Drop for PtraceMprotectGuard<'a> {
+    fn drop(&mut self) {
+        if !self.restored {
+            let _ = ptrace_inject_mprotect(self.target, self.region, self.original_prot);
+        }
+    }
+}
+
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 fn force_write_cross_process_memory(
     pid: u32,
@@ -285,14 +367,13 @@ fn force_write_cross_process_memory(
     let target = Pid::from_raw(pid as i32);
     let original_prot = prot_from_perms(&region.perms);
 
-    // Temporarily change page protection to writable via ptrace-injected mprotect.
-    ptrace_inject_mprotect(target, region, libc::PROT_READ | libc::PROT_WRITE)?;
-
+    let mut guard = PtraceMprotectGuard::make_writable(target, region, original_prot)?;
     let result = process_vm_writev_data(pid, address, data);
 
-    // Best-effort restoration of original protection. We ignore restoration
-    // failures so the write result is still reported.
-    let _ = ptrace_inject_mprotect(target, region, original_prot);
+    // If the write succeeded, a restore failure must be reported to the caller.
+    if result.is_ok() {
+        guard.restore()?;
+    }
 
     result
 }
@@ -309,6 +390,39 @@ fn force_write_cross_process_memory(
     ))
 }
 
+/// Ensures the target process is detached from ptrace when this guard drops,
+/// even if the injection logic returns early or panics.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+struct PtraceAttachGuard {
+    target: nix::unistd::Pid,
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+impl Drop for PtraceAttachGuard {
+    fn drop(&mut self) {
+        let _ = nix::sys::ptrace::detach(self.target, None);
+    }
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn ptrace_scope_hint(errno: &nix::errno::Errno) -> String {
+    if *errno != nix::errno::Errno::EPERM {
+        return String::new();
+    }
+    match std::fs::read_to_string("/proc/sys/kernel/yama/ptrace_scope") {
+        Ok(content) => match content.trim().parse::<i32>() {
+            Ok(1) => " (Yama ptrace_scope=1: ptrace is restricted to parent-child relationships)"
+                .to_string(),
+            Ok(2) => {
+                " (Yama ptrace_scope=2: only administrators may use ptrace; try sudo)".to_string()
+            }
+            Ok(3) => " (Yama ptrace_scope=3: ptrace is disabled)".to_string(),
+            _ => String::new(),
+        },
+        Err(_) => String::new(),
+    }
+}
+
 /// Uses ptrace to inject an `mprotect` syscall into a stopped target process.
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 fn ptrace_inject_mprotect(
@@ -320,28 +434,30 @@ fn ptrace_inject_mprotect(
     use nix::sys::wait::{waitpid, WaitStatus};
 
     ptrace::attach(target).map_err(|e| {
+        let hint = ptrace_scope_hint(&e);
         BinfiddleError::ProcessMemoryError(format!(
-            "Failed to attach to process {}: {} (ensure ptrace access is permitted)",
-            target, e
+            "Failed to attach to process {}: {}{}",
+            target, e, hint
         ))
     })?;
 
-    let attach_result = match waitpid(target, None) {
-        Ok(WaitStatus::Stopped(_, _)) => Ok(()),
-        Ok(other) => Err(BinfiddleError::ProcessMemoryError(format!(
-            "Unexpected wait status while attaching to {}: {:?}",
-            target, other
-        ))),
-        Err(e) => Err(BinfiddleError::ProcessMemoryError(format!(
-            "waitpid failed after attach to {}: {}",
-            target, e
-        ))),
-    };
+    let _attach_guard = PtraceAttachGuard { target };
 
-    if let Err(e) = attach_result {
-        let _ = ptrace::detach(target, None);
-        return Err(e);
-    }
+    match waitpid(target, None) {
+        Ok(WaitStatus::Stopped(_, _)) => {}
+        Ok(other) => {
+            return Err(BinfiddleError::ProcessMemoryError(format!(
+                "Unexpected wait status while attaching to {}: {:?}",
+                target, other
+            )));
+        }
+        Err(e) => {
+            return Err(BinfiddleError::ProcessMemoryError(format!(
+                "waitpid failed after attach to {}: {}",
+                target, e
+            )));
+        }
+    };
 
     let inject_result = (|| {
         let mut regs = ptrace::getregs(target).map_err(|e| {
@@ -458,7 +574,7 @@ fn ptrace_inject_mprotect(
         Ok(())
     })();
 
-    let _ = ptrace::detach(target, None);
+    // PtraceAttachGuard::drop detaches the target even if inject_result is an Err.
     inject_result
 }
 
@@ -479,6 +595,88 @@ fn prot_from_perms(perms: &str) -> libc::c_int {
         prot |= libc::PROT_EXEC;
     }
     prot
+}
+
+/// Verifies that `[address, address + len)` fits inside `region`.
+fn check_region_bounds(region: &MemoryRegion, address: u64, len: usize) -> Result<()> {
+    let end = address.checked_add(len as u64).ok_or_else(|| {
+        BinfiddleError::ProcessMemoryError(format!(
+            "Write length {} at address 0x{:x} overflows the address space",
+            len, address
+        ))
+    })?;
+
+    if end > region.end {
+        return Err(BinfiddleError::ProcessMemoryError(format!(
+            "Write range 0x{:x}-0x{:x} extends beyond mapped region 0x{:x}-0x{:x}",
+            address, end, region.start, region.end
+        )));
+    }
+
+    Ok(())
+}
+
+/// RAII guard that temporarily makes a page-aligned range writable and restores
+/// the original protection when dropped or explicitly restored.
+#[cfg(target_os = "linux")]
+struct MprotectGuard {
+    addr: *mut libc::c_void,
+    len: usize,
+    original_prot: libc::c_int,
+    restored: bool,
+}
+
+#[cfg(target_os = "linux")]
+impl MprotectGuard {
+    fn make_writable(
+        protect_start: u64,
+        protect_len: u64,
+        original_prot: libc::c_int,
+    ) -> Result<Self> {
+        let addr = protect_start as *mut libc::c_void;
+        let len = protect_len as usize;
+
+        if unsafe { libc::mprotect(addr, len, libc::PROT_READ | libc::PROT_WRITE) } != 0 {
+            return Err(BinfiddleError::ProcessMemoryError(format!(
+                "mprotect failed for range 0x{:x}-0x{:x}: {}",
+                protect_start,
+                protect_start + protect_len,
+                std::io::Error::last_os_error()
+            )));
+        }
+
+        Ok(Self {
+            addr,
+            len,
+            original_prot,
+            restored: false,
+        })
+    }
+
+    fn restore(&mut self) -> Result<()> {
+        if self.restored {
+            return Ok(());
+        }
+
+        if unsafe { libc::mprotect(self.addr, self.len, self.original_prot) } != 0 {
+            return Err(BinfiddleError::ProcessMemoryError(format!(
+                "Failed to restore original memory protection for range {:?}: {}. Pages may still be writable!",
+                self.addr, std::io::Error::last_os_error()
+            )));
+        }
+
+        self.restored = true;
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for MprotectGuard {
+    fn drop(&mut self) {
+        if !self.restored {
+            let _ = unsafe { libc::mprotect(self.addr, self.len, self.original_prot) };
+        }
+    }
 }
 
 /// Parses `/proc/<pid>/maps` into a list of memory regions.
@@ -752,7 +950,89 @@ mod tests {
         unsafe {
             let bytes = std::slice::from_raw_parts(mapping as *const u8, 8);
             assert_eq!(bytes, b"FORCEWRT");
+
+            // Verify the temporary write permission was restored to read-only.
+            let regions = parse_maps(0).expect("should parse /proc/self/maps");
+            let region = find_region(&regions, address).expect("mapping should still exist");
+            assert!(
+                !region.is_writable(),
+                "Expected mapping to be restored to read-only, got perms: {}",
+                region.perms
+            );
+
             assert_eq!(libc::munmap(mapping, page_size), 0);
+        }
+    }
+
+    #[test]
+    fn test_check_region_bounds() {
+        let region = MemoryRegion {
+            start: 0x1000,
+            end: 0x2000,
+            perms: "rw-p".to_string(),
+            offset: 0,
+            dev: "00:00".to_string(),
+            inode: 0,
+            pathname: None,
+        };
+
+        assert!(check_region_bounds(&region, 0x1000, 0x1000).is_ok());
+        assert!(check_region_bounds(&region, 0x1fff, 1).is_ok());
+        assert!(check_region_bounds(&region, 0x1fff, 2).is_err());
+        assert!(check_region_bounds(&region, 0x2000, 1).is_err());
+    }
+
+    #[test]
+    fn test_write_self_past_region_end_fails() {
+        let page_size = page_size() as usize;
+        let mapping = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                page_size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        assert!(!mapping.is_null());
+
+        let address = mapping as u64 + page_size as u64 - 1;
+        let result = write_process_memory(0, address, &[0u8; 2], false);
+        assert!(
+            result.is_err(),
+            "Expected boundary check to reject writes past region end"
+        );
+
+        unsafe {
+            libc::munmap(mapping, page_size);
+        }
+    }
+
+    #[test]
+    fn test_write_cross_process_past_region_end_fails() {
+        let page_size = page_size() as usize;
+        let mapping = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                page_size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        assert!(!mapping.is_null());
+
+        let address = mapping as u64 + page_size as u64 - 1;
+        let result = write_process_memory(std::process::id(), address, &[0u8; 2], false);
+        assert!(
+            result.is_err(),
+            "Expected boundary check to reject writes past region end"
+        );
+
+        unsafe {
+            libc::munmap(mapping, page_size);
         }
     }
 }

--- a/src/process_memory.rs
+++ b/src/process_memory.rs
@@ -312,7 +312,10 @@ fn process_vm_writev_data(pid: u32, address: u64, data: &[u8]) -> Result<()> {
 /// RAII guard that temporarily makes a remote memory region writable via
 /// ptrace-injected `mprotect` and restores the original protection on drop or
 /// explicit restore.
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[cfg(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 struct PtraceMprotectGuard<'a> {
     target: nix::unistd::Pid,
     region: &'a MemoryRegion,
@@ -320,7 +323,10 @@ struct PtraceMprotectGuard<'a> {
     restored: bool,
 }
 
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[cfg(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 impl<'a> PtraceMprotectGuard<'a> {
     fn make_writable(
         target: nix::unistd::Pid,
@@ -346,7 +352,10 @@ impl<'a> PtraceMprotectGuard<'a> {
     }
 }
 
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[cfg(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 impl<'a> Drop for PtraceMprotectGuard<'a> {
     fn drop(&mut self) {
         if !self.restored {
@@ -355,7 +364,10 @@ impl<'a> Drop for PtraceMprotectGuard<'a> {
     }
 }
 
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[cfg(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 fn force_write_cross_process_memory(
     pid: u32,
     address: u64,
@@ -378,7 +390,10 @@ fn force_write_cross_process_memory(
     result
 }
 
-#[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+#[cfg(not(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+)))]
 fn force_write_cross_process_memory(
     _pid: u32,
     _address: u64,
@@ -386,25 +401,26 @@ fn force_write_cross_process_memory(
     _region: &MemoryRegion,
 ) -> Result<()> {
     Err(BinfiddleError::UnsupportedOperation(
-        "--force-writable for cross-process writes is only supported on Linux x86_64".to_string(),
+        "--force-writable for cross-process writes is only supported on Linux x86_64 and aarch64"
+            .to_string(),
     ))
 }
 
 /// Ensures the target process is detached from ptrace when this guard drops,
 /// even if the injection logic returns early or panics.
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[cfg(target_os = "linux")]
 struct PtraceAttachGuard {
     target: nix::unistd::Pid,
 }
 
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[cfg(target_os = "linux")]
 impl Drop for PtraceAttachGuard {
     fn drop(&mut self) {
         let _ = nix::sys::ptrace::detach(self.target, None);
     }
 }
 
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[cfg(target_os = "linux")]
 fn ptrace_scope_hint(errno: &nix::errno::Errno) -> String {
     if *errno != nix::errno::Errno::EPERM {
         return String::new();
@@ -424,8 +440,27 @@ fn ptrace_scope_hint(errno: &nix::errno::Errno) -> String {
 }
 
 /// Uses ptrace to inject an `mprotect` syscall into a stopped target process.
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[cfg(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 fn ptrace_inject_mprotect(
+    target: nix::unistd::Pid,
+    region: &MemoryRegion,
+    prot: libc::c_int,
+) -> Result<()> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        ptrace_inject_mprotect_x86_64(target, region, prot)
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        ptrace_inject_mprotect_aarch64(target, region, prot)
+    }
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn ptrace_inject_mprotect_x86_64(
     target: nix::unistd::Pid,
     region: &MemoryRegion,
     prot: libc::c_int,
@@ -573,6 +608,189 @@ fn ptrace_inject_mprotect(
 
         Ok(())
     })();
+
+    // PtraceAttachGuard::drop detaches the target even if inject_result is an Err.
+    inject_result
+}
+
+/// Writes a 32-bit value into a 64-bit aligned ptrace word, preserving the
+/// surrounding 32 bits. Used on aarch64 to inject a single `svc #0` instruction
+/// without corrupting the adjacent instruction.
+#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+fn ptrace_write_u32_at(target: nix::unistd::Pid, address: u64, value: u32) -> Result<()> {
+    use nix::sys::ptrace;
+
+    let aligned = address & !7;
+    let shift = (address - aligned) * 8;
+    let original = ptrace::read(target, aligned as *mut libc::c_void).map_err(|e| {
+        BinfiddleError::ProcessMemoryError(format!(
+            "Failed to read injection point from {}: {}",
+            target, e
+        ))
+    })? as u64;
+
+    let mask = !(0xffff_ffff_u64 << shift);
+    let new_word = (original & mask) | ((value as u64) << shift);
+
+    ptrace::write(target, aligned as *mut libc::c_void, new_word as i64).map_err(|e| {
+        BinfiddleError::ProcessMemoryError(format!(
+            "Failed to write injected instruction to {}: {}",
+            target, e
+        ))
+    })
+}
+
+#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+fn ptrace_inject_mprotect_aarch64(
+    target: nix::unistd::Pid,
+    region: &MemoryRegion,
+    prot: libc::c_int,
+) -> Result<()> {
+    use nix::sys::ptrace;
+    use nix::sys::wait::{waitpid, WaitStatus};
+
+    const SVC_0: u32 = 0xd4000001;
+
+    ptrace::attach(target).map_err(|e| {
+        let hint = ptrace_scope_hint(&e);
+        BinfiddleError::ProcessMemoryError(format!(
+            "Failed to attach to process {}: {}{}",
+            target, e, hint
+        ))
+    })?;
+
+    let _attach_guard = PtraceAttachGuard { target };
+
+    match waitpid(target, None) {
+        Ok(WaitStatus::Stopped(_, _)) => {}
+        Ok(other) => {
+            return Err(BinfiddleError::ProcessMemoryError(format!(
+                "Unexpected wait status while attaching to {}: {:?}",
+                target, other
+            )));
+        }
+        Err(e) => {
+            return Err(BinfiddleError::ProcessMemoryError(format!(
+                "waitpid failed after attach to {}: {}",
+                target, e
+            )));
+        }
+    };
+
+    // State captured during injection so we can always restore it.
+    let mut pc: Option<u64> = None;
+    let mut saved_regs: Option<nix::libc::user_regs_struct> = None;
+    let mut original_word: Option<u64> = None;
+
+    let inject_result = (|| {
+        let mut regs = ptrace::getregs(target).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to read registers of {}: {}",
+                target, e
+            ))
+        })?;
+
+        let current_pc = regs.pc;
+        pc = Some(current_pc);
+        saved_regs = Some(regs);
+
+        let page_size = page_size();
+        let protect_start = region.start & !(page_size - 1);
+        let protect_end = (region.end + page_size - 1) & !(page_size - 1);
+        let protect_len = protect_end - protect_start;
+
+        let word = ptrace::read(target, current_pc as *mut libc::c_void).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to read injection point from {}: {}",
+                target, e
+            ))
+        })? as u64;
+        original_word = Some(word);
+
+        ptrace_write_u32_at(target, current_pc, SVC_0)?;
+
+        // aarch64 syscall ABI: x0-x2 args, x8 syscall number.
+        regs.regs[0] = protect_start;
+        regs.regs[1] = protect_len;
+        regs.regs[2] = prot as u64;
+        regs.regs[8] = libc::SYS_mprotect as u64;
+        // pc already points at the injected svc #0.
+
+        ptrace::setregs(target, regs).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to set registers of {}: {}",
+                target, e
+            ))
+        })?;
+
+        // Run to syscall entry.
+        ptrace::syscall(target, None).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to continue {} to syscall entry: {}",
+                target, e
+            ))
+        })?;
+        match waitpid(target, None) {
+            Ok(WaitStatus::Stopped(_, nix::sys::signal::Signal::SIGTRAP)) => {}
+            Ok(other) => {
+                return Err(BinfiddleError::ProcessMemoryError(format!(
+                    "Unexpected wait status at syscall entry for {}: {:?}",
+                    target, other
+                )));
+            }
+            Err(e) => {
+                return Err(BinfiddleError::ProcessMemoryError(format!(
+                    "waitpid failed at syscall entry for {}: {}",
+                    target, e
+                )));
+            }
+        };
+
+        // Run to syscall exit.
+        ptrace::syscall(target, None).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to continue {} to syscall exit: {}",
+                target, e
+            ))
+        })?;
+        match waitpid(target, None) {
+            Ok(WaitStatus::Stopped(_, nix::sys::signal::Signal::SIGTRAP)) => {}
+            Ok(other) => {
+                return Err(BinfiddleError::ProcessMemoryError(format!(
+                    "Unexpected wait status at syscall exit for {}: {:?}",
+                    target, other
+                )));
+            }
+            Err(e) => {
+                return Err(BinfiddleError::ProcessMemoryError(format!(
+                    "waitpid failed at syscall exit for {}: {}",
+                    target, e
+                )));
+            }
+        };
+
+        let post_regs = ptrace::getregs(target).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to read post-syscall registers of {}: {}",
+                target, e
+            ))
+        })?;
+
+        if post_regs.regs[0] as i64 != 0 {
+            return Err(BinfiddleError::ProcessMemoryError(format!(
+                "mprotect syscall in process {} returned error {}",
+                target, post_regs.regs[0] as i64
+            )));
+        }
+
+        Ok(())
+    })();
+
+    // Best-effort restoration of original code and registers.
+    if let (Some(current_pc), Some(word), Some(saved)) = (pc, original_word, saved_regs) {
+        let _ = ptrace::write(target, current_pc as *mut libc::c_void, word as i64);
+        let _ = ptrace::setregs(target, saved);
+    }
 
     // PtraceAttachGuard::drop detaches the target even if inject_result is an Err.
     inject_result

--- a/src/process_memory.rs
+++ b/src/process_memory.rs
@@ -1,0 +1,378 @@
+//! Process memory access helpers (Linux-only).
+//!
+//! This module provides a minimal, read-mostly interface to `/proc/<pid>/mem`
+//! and `/proc/<pid>/maps`. It is intentionally scoped to Linux and focuses on
+//! same-user process inspection.
+
+use crate::{BinfiddleError, Result};
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+
+/// Describes a single memory region parsed from `/proc/<pid>/maps`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryRegion {
+    pub start: u64,
+    pub end: u64,
+    pub perms: String,
+    pub offset: u64,
+    pub dev: String,
+    pub inode: u64,
+    pub pathname: Option<String>,
+}
+
+impl MemoryRegion {
+    /// Returns true if the region contains the given address.
+    pub fn contains(&self, address: u64) -> bool {
+        address >= self.start && address < self.end
+    }
+
+    /// Returns true if the region is writable.
+    pub fn is_writable(&self) -> bool {
+        self.perms.contains('w')
+    }
+
+    /// Returns true if the region is readable.
+    pub fn is_readable(&self) -> bool {
+        self.perms.contains('r')
+    }
+}
+
+/// Returns the path to a process's `/proc/<pid>/mem` file.
+///
+/// Uses `/proc/self/mem` when the pid is the current process so tests and
+/// self-introspection work without caring about the actual pid.
+fn proc_mem_path(pid: u32) -> PathBuf {
+    if pid == 0 || pid == std::process::id() {
+        PathBuf::from("/proc/self/mem")
+    } else {
+        PathBuf::from(format!("/proc/{}/mem", pid))
+    }
+}
+
+/// Returns the path to a process's `/proc/<pid>/maps` file.
+fn proc_maps_path(pid: u32) -> PathBuf {
+    if pid == 0 || pid == std::process::id() {
+        PathBuf::from("/proc/self/maps")
+    } else {
+        PathBuf::from(format!("/proc/{}/maps", pid))
+    }
+}
+
+/// Reads `size` bytes from `pid`'s memory starting at `address`.
+pub fn read_process_memory(pid: u32, address: u64, size: u64) -> Result<Vec<u8>> {
+    if size > usize::MAX as u64 {
+        return Err(BinfiddleError::ProcessMemoryError(
+            "Requested size exceeds addressable memory".to_string(),
+        ));
+    }
+    let size = size as usize;
+
+    let mut file = File::open(proc_mem_path(pid)).map_err(|e| {
+        BinfiddleError::ProcessMemoryError(format!(
+            "Failed to open /proc/{}/mem: {}",
+            pid_label(pid),
+            e
+        ))
+    })?;
+
+    file.seek(SeekFrom::Start(address)).map_err(|e| {
+        BinfiddleError::ProcessMemoryError(format!(
+            "Failed to seek to address 0x{:x} in process {}: {}",
+            address,
+            pid_label(pid),
+            e
+        ))
+    })?;
+
+    let mut buffer = vec![0u8; size];
+    let mut total_read = 0usize;
+
+    while total_read < size {
+        match file.read(&mut buffer[total_read..]) {
+            Ok(0) => {
+                return Err(BinfiddleError::ProcessMemoryError(format!(
+                    "Short read while reading process {} memory at 0x{:x}: expected {}, got {}",
+                    pid_label(pid),
+                    address,
+                    size,
+                    total_read
+                )));
+            }
+            Ok(n) => total_read += n,
+            Err(e) => {
+                return Err(BinfiddleError::ProcessMemoryError(format!(
+                    "Failed to read process {} memory at 0x{:x}: {}",
+                    pid_label(pid),
+                    address + total_read as u64,
+                    e
+                )));
+            }
+        }
+    }
+
+    Ok(buffer)
+}
+
+/// Writes `data` to `pid`'s memory starting at `address`.
+///
+/// For this version cross-process writes are explicitly rejected; only the
+/// current process can be written to.
+pub fn write_process_memory(pid: u32, address: u64, data: &[u8]) -> Result<()> {
+    if pid != 0 && pid != std::process::id() {
+        return Err(BinfiddleError::ProcessMemoryError(
+            "Cross-process writes are not supported in this version".to_string(),
+        ));
+    }
+
+    let mut file = File::options()
+        .read(true)
+        .write(true)
+        .open(proc_mem_path(pid))
+        .map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to open /proc/{}/mem for writing: {}",
+                pid_label(pid),
+                e
+            ))
+        })?;
+
+    file.seek(SeekFrom::Start(address)).map_err(|e| {
+        BinfiddleError::ProcessMemoryError(format!(
+            "Failed to seek to address 0x{:x} for writing: {}",
+            address, e
+        ))
+    })?;
+
+    file.write_all(data).map_err(|e| {
+        BinfiddleError::ProcessMemoryError(format!(
+            "Failed to write process memory at 0x{:x}: {}",
+            address, e
+        ))
+    })?;
+
+    Ok(())
+}
+
+/// Parses `/proc/<pid>/maps` into a list of memory regions.
+pub fn parse_maps(pid: u32) -> Result<Vec<MemoryRegion>> {
+    let content = std::fs::read_to_string(proc_maps_path(pid)).map_err(|e| {
+        BinfiddleError::ProcessMemoryError(format!(
+            "Failed to read /proc/{}/maps: {}",
+            pid_label(pid),
+            e
+        ))
+    })?;
+
+    let mut regions = Vec::new();
+    for line in content.lines() {
+        if line.is_empty() {
+            continue;
+        }
+
+        let mut parts = line.splitn(6, ' ');
+        let range = parts.next().ok_or_else(|| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Malformed /proc/{}/maps line: {}",
+                pid_label(pid),
+                line
+            ))
+        })?;
+
+        let (start, end) = parse_range(range).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to parse region range in /proc/{}/maps: {}",
+                pid_label(pid),
+                e
+            ))
+        })?;
+
+        let perms = parts.next().unwrap_or("").to_string();
+        let offset = parts.next().unwrap_or("0");
+        let dev = parts.next().unwrap_or("").to_string();
+        let inode = parts.next().unwrap_or("0");
+
+        // Remaining whitespace-separated tokens are the pathname (may contain spaces).
+        let pathname = parts
+            .next()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        let offset = u64::from_str_radix(offset, 16).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to parse offset '{}' in /proc/{}/maps: {}",
+                offset,
+                pid_label(pid),
+                e
+            ))
+        })?;
+
+        let inode = inode.parse::<u64>().map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to parse inode '{}' in /proc/{}/maps: {}",
+                inode,
+                pid_label(pid),
+                e
+            ))
+        })?;
+
+        regions.push(MemoryRegion {
+            start,
+            end,
+            perms,
+            offset,
+            dev,
+            inode,
+            pathname,
+        });
+    }
+
+    Ok(regions)
+}
+
+/// Finds the memory region containing `address`.
+pub fn find_region(regions: &[MemoryRegion], address: u64) -> Option<&MemoryRegion> {
+    regions.iter().find(|r| r.contains(address))
+}
+
+/// Helper to print a list of memory regions in a human-readable table.
+pub fn format_regions(regions: &[MemoryRegion]) -> String {
+    let mut output = String::new();
+    output.push_str("Memory regions:\n");
+    output.push_str(&format!(
+        "{:<18} {:<18} {:<5} {:<10} {:<6} {:<10} {}\n",
+        "Start", "End", "Perms", "Offset", "Dev", "Inode", "Pathname"
+    ));
+
+    for r in regions {
+        let pathname = r.pathname.as_deref().unwrap_or("");
+        output.push_str(&format!(
+            "{:<18x} {:<18x} {:<5} {:<10x} {:<6} {:<10} {}\n",
+            r.start, r.end, r.perms, r.offset, r.dev, r.inode, pathname
+        ));
+    }
+
+    output
+}
+
+fn parse_range(range: &str) -> Result<(u64, u64)> {
+    let (start, end) = range
+        .split_once('-')
+        .ok_or_else(|| BinfiddleError::Parse(format!("Invalid memory region range: {}", range)))?;
+
+    let start = u64::from_str_radix(start, 16)
+        .map_err(|e| BinfiddleError::Parse(format!("Invalid start address '{}': {}", start, e)))?;
+    let end = u64::from_str_radix(end, 16)
+        .map_err(|e| BinfiddleError::Parse(format!("Invalid end address '{}': {}", end, e)))?;
+
+    Ok((start, end))
+}
+
+fn pid_label(pid: u32) -> String {
+    if pid == 0 || pid == std::process::id() {
+        "self".to_string()
+    } else {
+        pid.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_maps_sample() {
+        let sample = "00400000-00452000 r-xp 00000000 08:02 173521      /usr/bin/dash\n\
+                      00452000-00453000 r--p 00052000 08:02 173521      /usr/bin/dash\n\
+                      00453000-00454000 rw-p 00053000 08:02 173521      /usr/bin/dash\n";
+
+        let mut regions = Vec::new();
+        for line in sample.lines() {
+            let mut parts = line.splitn(6, ' ');
+            let range = parts.next().unwrap();
+            let (start, end) = parse_range(range).unwrap();
+            let perms = parts.next().unwrap().to_string();
+            let offset = u64::from_str_radix(parts.next().unwrap(), 16).unwrap();
+            let dev = parts.next().unwrap().to_string();
+            let inode = parts.next().unwrap().parse::<u64>().unwrap();
+            let pathname = parts.next().map(|s| s.trim().to_string());
+            regions.push(MemoryRegion {
+                start,
+                end,
+                perms,
+                offset,
+                dev,
+                inode,
+                pathname,
+            });
+        }
+
+        assert_eq!(regions.len(), 3);
+        assert_eq!(regions[0].perms, "r-xp");
+        assert!(!regions[0].is_writable());
+        assert_eq!(regions[2].perms, "rw-p");
+        assert!(regions[2].is_writable());
+    }
+
+    #[test]
+    fn test_read_current_process_memory() {
+        static TEST_DATA: [u8; 8] = *b"PROCMEM!";
+        let address = &TEST_DATA as *const _ as u64;
+
+        let data = read_process_memory(0, address, TEST_DATA.len() as u64).unwrap();
+        assert_eq!(data, &TEST_DATA[..]);
+    }
+
+    #[test]
+    fn test_find_region() {
+        let regions = vec![
+            MemoryRegion {
+                start: 0x1000,
+                end: 0x2000,
+                perms: "rw-p".to_string(),
+                offset: 0,
+                dev: "00:00".to_string(),
+                inode: 0,
+                pathname: None,
+            },
+            MemoryRegion {
+                start: 0x2000,
+                end: 0x3000,
+                perms: "r-xp".to_string(),
+                offset: 0,
+                dev: "00:00".to_string(),
+                inode: 0,
+                pathname: None,
+            },
+        ];
+
+        assert!(find_region(&regions, 0x1500).unwrap().is_writable());
+        assert!(!find_region(&regions, 0x2500).unwrap().is_writable());
+        assert!(find_region(&regions, 0x500).is_none());
+    }
+
+    #[test]
+    fn test_write_current_process_memory() {
+        static mut TEST_BUFFER: [u8; 8] = [0u8; 8];
+        let address = std::ptr::addr_of!(TEST_BUFFER) as u64;
+
+        // Write via process memory interface.
+        write_process_memory(0, address, b"WRITEBUF").unwrap();
+
+        unsafe {
+            assert_eq!(&TEST_BUFFER[..], b"WRITEBUF");
+            // Restore to avoid side effects.
+            TEST_BUFFER = [0u8; 8];
+        }
+    }
+
+    #[test]
+    fn test_cross_process_write_rejected() {
+        // 0xFFFFFFFF is unlikely to be a valid pid; the rejection should happen
+        // before any syscall.
+        let result = write_process_memory(0xFFFF_FFFF, 0x1000, b"data");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Cross-process writes are not supported"));
+    }
+}

--- a/src/process_memory.rs
+++ b/src/process_memory.rs
@@ -118,12 +118,24 @@ pub fn read_process_memory(pid: u32, address: u64, size: u64) -> Result<Vec<u8>>
 ///
 /// - For the current process, `/proc/self/mem` is used.
 /// - For other processes, `process_vm_writev` is used and the target region
-///   must already be writable.
-pub fn write_process_memory(pid: u32, address: u64, data: &[u8]) -> Result<()> {
+///   must already be writable, unless `force_writable` is set.
+/// - When `force_writable` is set, read-only pages are temporarily made
+///   writable via `mprotect` (self) or ptrace syscall injection (cross-process),
+///   then restored.
+pub fn write_process_memory(
+    pid: u32,
+    address: u64,
+    data: &[u8],
+    force_writable: bool,
+) -> Result<()> {
     if pid == 0 || pid == std::process::id() {
-        write_self_memory(address, data)
+        if force_writable {
+            force_write_self_memory(address, data)
+        } else {
+            write_self_memory(address, data)
+        }
     } else {
-        write_cross_process_memory(pid, address, data)
+        write_cross_process_memory(pid, address, data, force_writable)
     }
 }
 
@@ -156,7 +168,57 @@ fn write_self_memory(address: u64, data: &[u8]) -> Result<()> {
     Ok(())
 }
 
-fn write_cross_process_memory(pid: u32, address: u64, data: &[u8]) -> Result<()> {
+fn force_write_self_memory(address: u64, data: &[u8]) -> Result<()> {
+    let regions = parse_maps(0)?;
+    let region = find_region(&regions, address).ok_or_else(|| {
+        BinfiddleError::ProcessMemoryError(format!(
+            "Address 0x{:x} is not in any mapped region of the current process",
+            address
+        ))
+    })?;
+
+    let original_prot = prot_from_perms(&region.perms);
+
+    let page_size = page_size();
+    let protect_start = region.start & !(page_size - 1);
+    let protect_end = (region.end + page_size - 1) & !(page_size - 1);
+    let protect_len = protect_end - protect_start;
+
+    let result = unsafe {
+        if libc::mprotect(
+            protect_start as *mut libc::c_void,
+            protect_len as usize,
+            libc::PROT_READ | libc::PROT_WRITE,
+        ) != 0
+        {
+            Err(BinfiddleError::ProcessMemoryError(format!(
+                "mprotect failed for region 0x{:x}-0x{:x}: {}",
+                protect_start,
+                protect_end,
+                std::io::Error::last_os_error()
+            )))
+        } else {
+            write_self_memory(address, data)
+        }
+    };
+
+    unsafe {
+        let _ = libc::mprotect(
+            protect_start as *mut libc::c_void,
+            protect_len as usize,
+            original_prot,
+        );
+    }
+
+    result
+}
+
+fn write_cross_process_memory(
+    pid: u32,
+    address: u64,
+    data: &[u8],
+    force_writable: bool,
+) -> Result<()> {
     let regions = parse_maps(pid)?;
     let region = find_region(&regions, address).ok_or_else(|| {
         BinfiddleError::ProcessMemoryError(format!(
@@ -165,13 +227,23 @@ fn write_cross_process_memory(pid: u32, address: u64, data: &[u8]) -> Result<()>
         ))
     })?;
 
-    if !region.is_writable() {
+    if !region.is_writable() && !force_writable {
         return Err(BinfiddleError::ProcessMemoryError(format!(
-            "Memory region 0x{:x}-0x{:x} in process {} is not writable",
+            "Memory region 0x{:x}-0x{:x} in process {} is not writable (use --force-writable to override)",
             region.start, region.end, pid
         )));
     }
 
+    if force_writable {
+        force_write_cross_process_memory(pid, address, data, region)?;
+    } else {
+        process_vm_writev_data(pid, address, data)?;
+    }
+
+    Ok(())
+}
+
+fn process_vm_writev_data(pid: u32, address: u64, data: &[u8]) -> Result<()> {
     let local_iov = libc::iovec {
         iov_base: data.as_ptr() as *mut libc::c_void,
         iov_len: data.len(),
@@ -199,6 +271,214 @@ fn write_cross_process_memory(pid: u32, address: u64, data: &[u8]) -> Result<()>
     }
 
     Ok(())
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn force_write_cross_process_memory(
+    pid: u32,
+    address: u64,
+    data: &[u8],
+    region: &MemoryRegion,
+) -> Result<()> {
+    use nix::unistd::Pid;
+
+    let target = Pid::from_raw(pid as i32);
+    let original_prot = prot_from_perms(&region.perms);
+
+    // Temporarily change page protection to writable via ptrace-injected mprotect.
+    ptrace_inject_mprotect(target, region, libc::PROT_READ | libc::PROT_WRITE)?;
+
+    let result = process_vm_writev_data(pid, address, data);
+
+    // Best-effort restoration of original protection. We ignore restoration
+    // failures so the write result is still reported.
+    let _ = ptrace_inject_mprotect(target, region, original_prot);
+
+    result
+}
+
+#[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+fn force_write_cross_process_memory(
+    _pid: u32,
+    _address: u64,
+    _data: &[u8],
+    _region: &MemoryRegion,
+) -> Result<()> {
+    Err(BinfiddleError::UnsupportedOperation(
+        "--force-writable for cross-process writes is only supported on Linux x86_64".to_string(),
+    ))
+}
+
+/// Uses ptrace to inject an `mprotect` syscall into a stopped target process.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn ptrace_inject_mprotect(
+    target: nix::unistd::Pid,
+    region: &MemoryRegion,
+    prot: libc::c_int,
+) -> Result<()> {
+    use nix::sys::ptrace;
+    use nix::sys::wait::{waitpid, WaitStatus};
+
+    ptrace::attach(target).map_err(|e| {
+        BinfiddleError::ProcessMemoryError(format!(
+            "Failed to attach to process {}: {} (ensure ptrace access is permitted)",
+            target, e
+        ))
+    })?;
+
+    let attach_result = match waitpid(target, None) {
+        Ok(WaitStatus::Stopped(_, _)) => Ok(()),
+        Ok(other) => Err(BinfiddleError::ProcessMemoryError(format!(
+            "Unexpected wait status while attaching to {}: {:?}",
+            target, other
+        ))),
+        Err(e) => Err(BinfiddleError::ProcessMemoryError(format!(
+            "waitpid failed after attach to {}: {}",
+            target, e
+        ))),
+    };
+
+    if let Err(e) = attach_result {
+        let _ = ptrace::detach(target, None);
+        return Err(e);
+    }
+
+    let inject_result = (|| {
+        let mut regs = ptrace::getregs(target).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to read registers of {}: {}",
+                target, e
+            ))
+        })?;
+        let saved_regs = regs;
+        let rip = regs.rip;
+
+        let page_size = page_size();
+        let protect_start = region.start & !(page_size - 1);
+        let protect_end = (region.end + page_size - 1) & !(page_size - 1);
+        let protect_len = protect_end - protect_start;
+
+        // Save the two words at the injection point so we can restore them.
+        let original_word1 = ptrace::read(target, rip as *mut libc::c_void).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to read injection point from {}: {}",
+                target, e
+            ))
+        })? as u64;
+        let original_word2 = ptrace::read(target, (rip + 8) as *mut libc::c_void).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to read injection point from {}: {}",
+                target, e
+            ))
+        })? as u64;
+
+        // Inject: syscall (0x0f 0x05); int3 (0xcc); padding
+        let injected_word1 = u64::from_le_bytes([0x0f, 0x05, 0xcc, 0x90, 0x90, 0x90, 0x90, 0x90]);
+        ptrace::write(target, rip as *mut libc::c_void, injected_word1 as i64).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to write injected syscall to {}: {}",
+                target, e
+            ))
+        })?;
+
+        // Set up mprotect syscall arguments (x86_64 syscall ABI).
+        regs.rax = libc::SYS_mprotect as u64;
+        regs.rdi = protect_start;
+        regs.rsi = protect_len;
+        regs.rdx = prot as u64;
+        regs.rip = rip;
+
+        ptrace::setregs(target, regs).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to set registers of {}: {}",
+                target, e
+            ))
+        })?;
+
+        ptrace::cont(target, None).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to continue {} for mprotect injection: {}",
+                target, e
+            ))
+        })?;
+
+        let wait_result = waitpid(target, None).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "waitpid failed during mprotect injection for {}: {}",
+                target, e
+            ))
+        })?;
+
+        if !matches!(
+            wait_result,
+            WaitStatus::Stopped(_, nix::sys::signal::Signal::SIGTRAP)
+        ) {
+            return Err(BinfiddleError::ProcessMemoryError(format!(
+                "Unexpected wait status during mprotect injection for {}: {:?}",
+                target, wait_result
+            )));
+        }
+
+        let post_regs = ptrace::getregs(target).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to read post-syscall registers of {}: {}",
+                target, e
+            ))
+        })?;
+
+        if post_regs.rax as i64 != 0 {
+            return Err(BinfiddleError::ProcessMemoryError(format!(
+                "mprotect syscall in process {} returned error {}",
+                target, post_regs.rax as i64
+            )));
+        }
+
+        // Restore original code words.
+        ptrace::write(target, rip as *mut libc::c_void, original_word1 as i64).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to restore first word at {}: {}",
+                target, e
+            ))
+        })?;
+        // Second word was never modified, but restore for completeness.
+        let _ = ptrace::write(
+            target,
+            (rip + 8) as *mut libc::c_void,
+            original_word2 as i64,
+        );
+
+        // Restore original registers.
+        ptrace::setregs(target, saved_regs).map_err(|e| {
+            BinfiddleError::ProcessMemoryError(format!(
+                "Failed to restore registers of {}: {}",
+                target, e
+            ))
+        })?;
+
+        Ok(())
+    })();
+
+    let _ = ptrace::detach(target, None);
+    inject_result
+}
+
+fn page_size() -> u64 {
+    // Safe: sysconf is always successful for _SC_PAGE_SIZE on Linux.
+    unsafe { libc::sysconf(libc::_SC_PAGE_SIZE) as u64 }
+}
+
+fn prot_from_perms(perms: &str) -> libc::c_int {
+    let mut prot = libc::PROT_NONE;
+    if perms.contains('r') {
+        prot |= libc::PROT_READ;
+    }
+    if perms.contains('w') {
+        prot |= libc::PROT_WRITE;
+    }
+    if perms.contains('x') {
+        prot |= libc::PROT_EXEC;
+    }
+    prot
 }
 
 /// Parses `/proc/<pid>/maps` into a list of memory regions.
@@ -404,7 +684,7 @@ mod tests {
         let address = std::ptr::addr_of!(TEST_BUFFER) as u64;
 
         // Write via process memory interface.
-        write_process_memory(0, address, b"WRITEBUF").unwrap();
+        write_process_memory(0, address, b"WRITEBUF", false).unwrap();
 
         unsafe {
             assert_eq!(&TEST_BUFFER[..], b"WRITEBUF");
@@ -420,7 +700,7 @@ mod tests {
         static mut TEST_BUFFER: [u8; 8] = [0u8; 8];
         let address = std::ptr::addr_of!(TEST_BUFFER) as u64;
 
-        write_process_memory(std::process::id(), address, b"PIDWRITE").unwrap();
+        write_process_memory(std::process::id(), address, b"PIDWRITE", false).unwrap();
 
         unsafe {
             assert_eq!(&TEST_BUFFER[..], b"PIDWRITE");
@@ -441,5 +721,38 @@ mod tests {
             "Expected .rodata region to be non-writable, got perms: {}",
             region.perms
         );
+    }
+
+    #[test]
+    fn test_force_write_self_memory_changes_readonly_mapping() {
+        // Allocate a page, make it read-only, then use --force-writable to
+        // temporarily restore write permission and modify it.
+        let page_size = page_size() as usize;
+        let mapping = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                page_size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        assert!(!mapping.is_null());
+
+        let address = mapping as u64;
+        let original = b"CHANGEME";
+        unsafe {
+            std::ptr::copy_nonoverlapping(original.as_ptr(), mapping as *mut u8, original.len());
+            assert_eq!(libc::mprotect(mapping, page_size, libc::PROT_READ), 0);
+        }
+
+        write_process_memory(0, address, b"FORCEWRT", true).unwrap();
+
+        unsafe {
+            let bytes = std::slice::from_raw_parts(mapping as *const u8, 8);
+            assert_eq!(bytes, b"FORCEWRT");
+            assert_eq!(libc::munmap(mapping, page_size), 0);
+        }
     }
 }

--- a/src/process_memory.rs
+++ b/src/process_memory.rs
@@ -116,23 +116,25 @@ pub fn read_process_memory(pid: u32, address: u64, size: u64) -> Result<Vec<u8>>
 
 /// Writes `data` to `pid`'s memory starting at `address`.
 ///
-/// For this version cross-process writes are explicitly rejected; only the
-/// current process can be written to.
+/// - For the current process, `/proc/self/mem` is used.
+/// - For other processes, `process_vm_writev` is used and the target region
+///   must already be writable.
 pub fn write_process_memory(pid: u32, address: u64, data: &[u8]) -> Result<()> {
-    if pid != 0 && pid != std::process::id() {
-        return Err(BinfiddleError::ProcessMemoryError(
-            "Cross-process writes are not supported in this version".to_string(),
-        ));
+    if pid == 0 || pid == std::process::id() {
+        write_self_memory(address, data)
+    } else {
+        write_cross_process_memory(pid, address, data)
     }
+}
 
+fn write_self_memory(address: u64, data: &[u8]) -> Result<()> {
     let mut file = File::options()
         .read(true)
         .write(true)
-        .open(proc_mem_path(pid))
+        .open("/proc/self/mem")
         .map_err(|e| {
             BinfiddleError::ProcessMemoryError(format!(
-                "Failed to open /proc/{}/mem for writing: {}",
-                pid_label(pid),
+                "Failed to open /proc/self/mem for writing: {}",
                 e
             ))
         })?;
@@ -150,6 +152,51 @@ pub fn write_process_memory(pid: u32, address: u64, data: &[u8]) -> Result<()> {
             address, e
         ))
     })?;
+
+    Ok(())
+}
+
+fn write_cross_process_memory(pid: u32, address: u64, data: &[u8]) -> Result<()> {
+    let regions = parse_maps(pid)?;
+    let region = find_region(&regions, address).ok_or_else(|| {
+        BinfiddleError::ProcessMemoryError(format!(
+            "Address 0x{:x} is not in any mapped region of process {}",
+            address, pid
+        ))
+    })?;
+
+    if !region.is_writable() {
+        return Err(BinfiddleError::ProcessMemoryError(format!(
+            "Memory region 0x{:x}-0x{:x} in process {} is not writable",
+            region.start, region.end, pid
+        )));
+    }
+
+    let local_iov = libc::iovec {
+        iov_base: data.as_ptr() as *mut libc::c_void,
+        iov_len: data.len(),
+    };
+    let remote_iov = libc::iovec {
+        iov_base: address as *mut libc::c_void,
+        iov_len: data.len(),
+    };
+
+    let ret =
+        unsafe { libc::process_vm_writev(pid as libc::pid_t, &local_iov, 1, &remote_iov, 1, 0) };
+
+    if ret < 0 {
+        let err = std::io::Error::last_os_error();
+        return Err(BinfiddleError::ProcessMemoryError(format!(
+            "process_vm_writev failed for pid {}: {} (ensure ptrace access is permitted)",
+            pid, err
+        )));
+    }
+
+    if ret as usize != data.len() {
+        return Err(BinfiddleError::ProcessMemoryError(
+            "Short write while writing process memory".to_string(),
+        ));
+    }
 
     Ok(())
 }
@@ -367,12 +414,32 @@ mod tests {
     }
 
     #[test]
-    fn test_cross_process_write_rejected() {
-        // 0xFFFFFFFF is unlikely to be a valid pid; the rejection should happen
-        // before any syscall.
-        let result = write_process_memory(0xFFFF_FFFF, 0x1000, b"data");
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("Cross-process writes are not supported"));
+    fn test_write_current_pid_uses_cross_process_path() {
+        // Using the actual pid exercises the process_vm_writev code path against
+        // the current process.
+        static mut TEST_BUFFER: [u8; 8] = [0u8; 8];
+        let address = std::ptr::addr_of!(TEST_BUFFER) as u64;
+
+        write_process_memory(std::process::id(), address, b"PIDWRITE").unwrap();
+
+        unsafe {
+            assert_eq!(&TEST_BUFFER[..], b"PIDWRITE");
+            TEST_BUFFER = [0u8; 8];
+        }
+    }
+
+    #[test]
+    fn test_readonly_region_detected_in_maps() {
+        // String literals live in .rodata, which is mapped read-only.
+        static RO_STRING: &str = "READONLY";
+        let address = RO_STRING.as_bytes().as_ptr() as u64;
+
+        let regions = parse_maps(0).expect("should parse /proc/self/maps");
+        let region = find_region(&regions, address).expect("address should be mapped");
+        assert!(
+            !region.is_writable(),
+            "Expected .rodata region to be non-writable, got perms: {}",
+            region.perms
+        );
     }
 }

--- a/src/process_memory.rs
+++ b/src/process_memory.rs
@@ -39,6 +39,18 @@ impl MemoryRegion {
     }
 }
 
+/// How to handle inaccessible bytes when reading process memory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FillMode {
+    /// Fail the read if any requested byte is not accessible.
+    #[default]
+    Error,
+    /// Replace inaccessible bytes with zeros.
+    ZeroFill,
+    /// Omit inaccessible bytes (the result may be shorter than requested).
+    Skip,
+}
+
 /// Returns the path to a process's `/proc/<pid>/maps` file.
 fn proc_maps_path(pid: u32) -> PathBuf {
     if pid == 0 || pid == std::process::id() {
@@ -48,14 +60,94 @@ fn proc_maps_path(pid: u32) -> PathBuf {
     }
 }
 
-/// Reads `size` bytes from `pid`'s memory starting at `address`.
+/// Reads `size` bytes from `pid`'s memory starting at `address`, failing if any
+/// part of the range is inaccessible.
 pub fn read_process_memory(pid: u32, address: u64, size: u64) -> Result<Vec<u8>> {
+    read_process_memory_sparse(pid, address, size, FillMode::Error)
+}
+
+/// Reads `size` bytes from `pid`'s memory starting at `address`, handling
+/// inaccessible gaps according to `fill_mode`.
+pub fn read_process_memory_sparse(
+    pid: u32,
+    address: u64,
+    size: u64,
+    fill_mode: FillMode,
+) -> Result<Vec<u8>> {
     if size > usize::MAX as u64 {
         return Err(BinfiddleError::ProcessMemoryError(
             "Requested size exceeds addressable memory".to_string(),
         ));
     }
+    if size == 0 {
+        return Ok(Vec::new());
+    }
 
+    let end = address + size;
+    let regions = parse_maps(pid)?;
+    let mut result = Vec::with_capacity(size as usize);
+    let mut pos = address;
+
+    for region in &regions {
+        if region.end <= pos {
+            continue;
+        }
+        if region.start >= end {
+            break;
+        }
+
+        if region.start > pos {
+            let gap = region.start - pos;
+            handle_inaccessible_gap(pos, gap, fill_mode, &mut result, pid)?;
+            pos = region.start;
+        }
+
+        let read_start = pos;
+        let read_end = region.end.min(end);
+        let read_len = read_end - read_start;
+
+        if !region.is_readable() {
+            handle_inaccessible_gap(read_start, read_len, fill_mode, &mut result, pid)?;
+            pos = read_end;
+            continue;
+        }
+
+        let chunk = read_process_memory_chunk(pid, read_start, read_len)?;
+        result.extend(chunk);
+        pos = read_end;
+    }
+
+    if pos < end {
+        let gap = end - pos;
+        handle_inaccessible_gap(pos, gap, fill_mode, &mut result, pid)?;
+    }
+
+    Ok(result)
+}
+
+fn handle_inaccessible_gap(
+    address: u64,
+    gap: u64,
+    fill_mode: FillMode,
+    result: &mut Vec<u8>,
+    pid: u32,
+) -> Result<()> {
+    match fill_mode {
+        FillMode::Error => Err(BinfiddleError::ProcessMemoryError(format!(
+            "Inaccessible process memory at 0x{:x}-0x{:x} in process {} (use --zero-fill-inaccessible or --skip-inaccessible)",
+            address,
+            address + gap,
+            pid_label(pid)
+        ))),
+        FillMode::ZeroFill => {
+            result.resize(result.len() + gap as usize, 0);
+            Ok(())
+        }
+        FillMode::Skip => Ok(()),
+    }
+}
+
+fn read_process_memory_chunk(pid: u32, address: u64, size: u64) -> Result<Vec<u8>> {
     if pid == 0 || pid == std::process::id() {
         read_self_memory(address, size)
     } else {
@@ -1215,8 +1307,14 @@ mod tests {
         };
         assert!(!mapping.is_null());
 
+        // Make the page read-only so the force-writable path is exercised and
+        // the VMA is unlikely to merge with adjacent writable mappings.
+        unsafe {
+            assert_eq!(libc::mprotect(mapping, page_size, libc::PROT_READ), 0);
+        }
+
         let address = mapping as u64 + page_size as u64 - 1;
-        let result = write_process_memory(0, address, &[0u8; 2], false);
+        let result = write_process_memory(0, address, &[0u8; 2], true);
         assert!(
             result.is_err(),
             "Expected boundary check to reject writes past region end"
@@ -1242,8 +1340,12 @@ mod tests {
         };
         assert!(!mapping.is_null());
 
+        unsafe {
+            assert_eq!(libc::mprotect(mapping, page_size, libc::PROT_READ), 0);
+        }
+
         let address = mapping as u64 + page_size as u64 - 1;
-        let result = write_process_memory(std::process::id(), address, &[0u8; 2], false);
+        let result = write_process_memory(std::process::id(), address, &[0u8; 2], true);
         assert!(
             result.is_err(),
             "Expected boundary check to reject writes past region end"
@@ -1251,6 +1353,59 @@ mod tests {
 
         unsafe {
             libc::munmap(mapping, page_size);
+        }
+    }
+
+    #[test]
+    fn test_sparse_read_with_protected_page() {
+        let page_size = page_size() as usize;
+        let mapping = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                page_size * 2,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        assert!(!mapping.is_null());
+
+        unsafe {
+            std::ptr::write_bytes(mapping as *mut u8, 0xab, page_size);
+            std::ptr::write_bytes((mapping as usize + page_size) as *mut u8, 0xcd, page_size);
+            assert_eq!(
+                libc::mprotect(
+                    (mapping as usize + page_size) as *mut libc::c_void,
+                    page_size,
+                    libc::PROT_NONE
+                ),
+                0
+            );
+        }
+
+        let address = mapping as u64;
+
+        let zero_filled =
+            read_process_memory_sparse(0, address, (page_size * 2) as u64, FillMode::ZeroFill)
+                .unwrap();
+        assert_eq!(zero_filled.len(), page_size * 2);
+        assert!(zero_filled[..page_size].iter().all(|&b| b == 0xab));
+        assert!(zero_filled[page_size..].iter().all(|&b| b == 0x00));
+
+        let skipped =
+            read_process_memory_sparse(0, address, (page_size * 2) as u64, FillMode::Skip).unwrap();
+        assert_eq!(skipped.len(), page_size);
+        assert!(skipped.iter().all(|&b| b == 0xab));
+
+        assert!(
+            read_process_memory_sparse(0, address, (page_size * 2) as u64, FillMode::Error)
+                .is_err(),
+            "Expected Error fill mode to fail on inaccessible page"
+        );
+
+        unsafe {
+            libc::munmap(mapping, page_size * 2);
         }
     }
 }

--- a/src/utils/display.rs
+++ b/src/utils/display.rs
@@ -92,7 +92,7 @@ pub fn display_bytes_with_offset(
     // Calculate bytes per line based on chunk_size and width
     // Each chunk is chunk_size bits, width chunks per line
     let bits_per_line = effective_width * chunk_size;
-    let bytes_per_line = (bits_per_line + 7) / 8; // ceiling division
+    let bytes_per_line = bits_per_line.div_ceil(8); // ceiling division
 
     // Determine address width based on max offset
     let max_addr = base_offset + bytes.len();
@@ -135,7 +135,7 @@ pub fn display_bytes_with_offset(
         if show_sidebar {
             output.push_str("  |");
             for &byte in chunk {
-                if byte >= 0x20 && byte <= 0x7E {
+                if (0x20..=0x7E).contains(&byte) {
                     output.push(byte as char);
                 } else {
                     output.push('.');
@@ -229,7 +229,7 @@ fn extract_bits(bytes: &[u8], bit_offset: usize, bit_count: usize) -> u64 {
 
 /// Formats a chunk value as hexadecimal.
 fn format_chunk_hex(value: u64, bit_count: usize) -> String {
-    let hex_digits = (bit_count + 3) / 4; // Ceiling division
+    let hex_digits = bit_count.div_ceil(4); // Ceiling division
     format!("{:0width$x}", value, width = hex_digits)
 }
 
@@ -257,7 +257,7 @@ fn format_ascii(bytes: &[u8], width: usize) -> Result<String> {
     let mut chars_on_line = 0;
 
     for (i, &byte) in bytes.iter().enumerate() {
-        let ch = if byte >= 0x20 && byte <= 0x7E {
+        let ch = if (0x20..=0x7E).contains(&byte) {
             byte as char
         } else {
             '.'

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,6 +4,7 @@
 /// src/utils/mod.rs
 pub mod display;
 pub mod parsing;
+pub mod progress;
 
 // Re-export commonly used functions at the module level
 pub use display::{display_bytes, display_bytes_with_offset};

--- a/src/utils/parsing.rs
+++ b/src/utils/parsing.rs
@@ -167,7 +167,7 @@ fn parse_hex_input(input: &str) -> Result<Vec<u8>> {
     // Remove common separators and whitespace
     let cleaned: String = input.chars().filter(|c| c.is_ascii_hexdigit()).collect();
 
-    if cleaned.len() % 2 != 0 {
+    if !cleaned.len().is_multiple_of(2) {
         return Err(BinfiddleError::Parse(format!(
             "Hex input must have even number of digits, got {} digits",
             cleaned.len()
@@ -314,7 +314,7 @@ fn parse_mask_pattern(input: &str) -> Result<SearchPattern> {
         .filter(|c| c.is_ascii_hexdigit() || *c == '?' || *c == 'x' || *c == 'X')
         .collect();
 
-    if cleaned.len() % 2 != 0 {
+    if !cleaned.len().is_multiple_of(2) {
         return Err(BinfiddleError::Parse(format!(
             "Mask pattern must have pairs of characters, got {} characters",
             cleaned.len()
@@ -597,18 +597,17 @@ pub fn validate_search_pattern(pattern: &str, format: &str) -> Vec<String> {
             }
         }
 
-        "mask" => {
-            // Check if wildcards are present
+        "mask"
             if !pattern.contains("??")
                 && !pattern.contains("XX")
-                && !pattern.to_uppercase().contains("XX")
-            {
-                warnings.push(format!(
-                    "💡 Pattern '{}' has no wildcards (?? or XX).\n\
-                    Did you mean: --input-format hex?",
-                    pattern
-                ));
-            }
+                && !pattern.to_uppercase().contains("XX") =>
+        {
+            // Pattern has no wildcards
+            warnings.push(format!(
+                "💡 Pattern '{}' has no wildcards (?? or XX).\n\
+                Did you mean: --input-format hex?",
+                pattern
+            ));
         }
 
         _ => {}

--- a/src/utils/progress.rs
+++ b/src/utils/progress.rs
@@ -16,9 +16,13 @@ impl Progress {
     ///
     /// - `total`: total number of bytes, or `None` for an indeterminate spinner.
     /// - `message`: short description shown on the left of the bar.
-    /// - `silent`: if true, the bar is hidden.
-    pub fn new(total: Option<u64>, message: &str, silent: bool) -> Self {
-        let hidden = silent || !atty::is(atty::Stream::Stderr);
+    /// - `enabled`: if false, the bar is hidden. Should be set from the
+    ///   `--progress` CLI flag (and combined with `--silent` by the caller).
+    pub fn new(total: Option<u64>, message: &str, enabled: bool) -> Self {
+        // Progress bars are opt-in only. Even when enabled, only draw them on
+        // an interactive stderr so pipes and scripts (including command
+        // chaining, which captures stderr) never get progress artifacts.
+        let hidden = !enabled || !atty::is(atty::Stream::Stderr);
         let bar = if hidden {
             ProgressBar::hidden()
         } else {

--- a/src/utils/progress.rs
+++ b/src/utils/progress.rs
@@ -1,0 +1,83 @@
+//! Progress-bar helpers for long-running commands.
+//!
+//! Wraps `indicatif` so commands can show progress when running in a terminal
+//! and stay quiet otherwise (or when `--silent` is set).
+
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use std::io::{self, Read};
+
+/// A thin wrapper around an `indicatif` progress bar.
+pub struct Progress {
+    bar: ProgressBar,
+}
+
+impl Progress {
+    /// Creates a new progress bar.
+    ///
+    /// - `total`: total number of bytes, or `None` for an indeterminate spinner.
+    /// - `message`: short description shown on the left of the bar.
+    /// - `silent`: if true, the bar is hidden.
+    pub fn new(total: Option<u64>, message: &str, silent: bool) -> Self {
+        let hidden = silent || !atty::is(atty::Stream::Stderr);
+        let bar = if hidden {
+            ProgressBar::hidden()
+        } else {
+            ProgressBar::new(total.unwrap_or(0))
+        };
+
+        if !hidden {
+            let style = match total {
+                Some(_) => ProgressStyle::with_template(
+                    "{msg} [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec}, ETA {eta})",
+                )
+                .unwrap()
+                .progress_chars("=>-"),
+                None => ProgressStyle::with_template("{spinner} {msg} {bytes} ({bytes_per_sec})")
+                    .unwrap(),
+            };
+            bar.set_style(style);
+            bar.set_message(message.to_string());
+            // Draw to stderr so stdout remains clean for command output.
+            bar.set_draw_target(ProgressDrawTarget::stderr());
+        }
+
+        Self { bar }
+    }
+
+    /// Advances the bar by `n` bytes.
+    pub fn inc(&self, n: u64) {
+        self.bar.inc(n);
+    }
+
+    /// Finishes the bar and clears it from the terminal.
+    pub fn finish(&self) {
+        self.bar.finish_and_clear();
+    }
+}
+
+/// A [`Read`] wrapper that increments a [`Progress`] bar as bytes are read.
+pub struct ProgressReader<R> {
+    inner: R,
+    progress: Progress,
+}
+
+impl<R> ProgressReader<R> {
+    /// Wraps a reader with a progress bar.
+    pub fn new(inner: R, progress: Progress) -> Self {
+        Self { inner, progress }
+    }
+}
+
+impl<R: Read> Read for ProgressReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.progress.inc(n as u64);
+        Ok(n)
+    }
+}
+
+impl<R> Drop for ProgressReader<R> {
+    fn drop(&mut self) {
+        self.progress.finish();
+    }
+}

--- a/structs_library/INDEX.md
+++ b/structs_library/INDEX.md
@@ -2,9 +2,9 @@
 
 ## Summary Statistics
 
-- **Total Templates**: 44
+- **Total Templates**: 45
 - **Categories**: 12
-- **New in this session**: 19 templates
+- **New in this session**: 20 templates
 - **Coverage**: Executables, Mobile, ML Models, Firmware, Containers, Filesystem, Network, Security
 
 ## Category Breakdown
@@ -87,9 +87,10 @@ Document file formats.
 
 **Coverage**: PDF
 
-### Network (6 templates)
+### Network (7 templates)
 Network protocol headers.
 
+- `can_frame.yaml` - CAN 2.0A standard frame header (bit-level)
 - `dns_header.yaml` - DNS message header (queries/responses)
 - `ethernet_frame.yaml` - Ethernet II frame header
 - `ipv4_header.yaml` - IPv4 packet header
@@ -97,7 +98,7 @@ Network protocol headers.
 - `tcp_header.yaml` - TCP segment header
 - `udp_header.yaml` - UDP datagram header
 
-**Coverage**: DNS, Ethernet, IPv4, IPv6, TCP, UDP
+**Coverage**: CAN, DNS, Ethernet, IPv4, IPv6, TCP, UDP
 
 ### Mobile (1 template)
 Mobile platform formats (Android, iOS).

--- a/structs_library/README.md
+++ b/structs_library/README.md
@@ -166,6 +166,35 @@ fields:
         type: u8
 ```
 
+### Bit-Level Field Example
+
+Fields can be declared at arbitrary bit positions and widths. Bit ordering
+follows the template's `endian` setting:
+
+- `endian: big` — MSB-first within each byte (network protocols, registers).
+- `endian: little` — LSB-first within each byte (some file formats).
+
+```yaml
+endian: big
+fields:
+  - name: data_offset
+    offset: 0x0C
+    bit_size: 4
+    type: u8
+
+  - name: reserved
+    offset: 0x0C
+    bit_offset: 4
+    bit_size: 3
+    type: u8
+
+  - name: ns_flag
+    offset: 0x0C
+    bit_offset: 7
+    bit_size: 1
+    type: u8
+```
+
 ### Array Example
 
 ```yaml

--- a/structs_library/README.md
+++ b/structs_library/README.md
@@ -6,13 +6,13 @@ Comprehensive collection of binary structure templates for use with the `binfidd
 
 ```bash
 # Parse a binary file using a template
-binfiddle struct structs_library/executables/elf64_header.yaml -i /bin/ls
+binfiddle struct structs_library/executables/elf64_header.yaml < /bin/ls
 
 # Get a specific field value
-binfiddle struct structs_library/images/png_header.yaml -i image.png --get width
+binfiddle struct structs_library/images/png_header.yaml --get width < image.png
 
 # Output as JSON
-binfiddle struct structs_library/network/ipv4_header.yaml -i packet.bin --format json
+binfiddle struct structs_library/network/ipv4_header.yaml --format json < packet.bin
 
 # List all fields in a template
 binfiddle struct structs_library/audio/wav_riff_header.yaml --list-fields
@@ -75,13 +75,18 @@ fields:
   - name: field_name
     offset: 0x00
     size: 4
-    type: u32  # u8, u16, u32, u64, i8, i16, i32, i64, hex_string, string, bytes
+    type: u32  # u8, u16, u32, u64, i8, i16, i32, i64, hex_string, string, bytes, computed
     description: "Field purpose"
     assert: "expected_value"  # Optional - validates field value
     enum:  # Optional - maps values to names
       0: "Zero"
       1: "One"
     display: hex  # Optional - format override (hex, dec, bin, oct)
+    when: $version >= 2  # Optional - conditional parsing
+    bitfields:  # Optional - extract bitfields from integer fields
+      - name: is_set
+        bits: 0
+        type: bool
 ```
 
 ## Supported Field Types
@@ -89,6 +94,92 @@ fields:
 - **Integers**: `u8`, `u16`, `u32`, `u64` (unsigned), `i8`, `i16`, `i32`, `i64` (signed)
 - **Strings**: `string` (ASCII/UTF-8, null-terminated or fixed length)
 - **Raw Data**: `hex_string` (displayed as hex), `bytes` (raw bytes)
+- **Computed**: `computed` — virtual field calculated from an expression
+
+## Dynamic Templates
+
+Templates support a small expression language for dynamic offsets, sizes, conditions, and computed values.
+
+### Expressions
+
+- **Field references**: `$fieldname`, `$fieldname.bitfield`
+- **Magic variables**:
+  - `$@current` — current parse offset
+  - `$@prev_end` — end of previous field
+  - `$@file_size` — total input size
+  - `$@base` — base offset of the current template
+- **Operators**: `+`, `-`, `*`, `/`, `%`, `**`, `==`, `!=`, `<`, `<=`, `>`, `>=`, `and`/`&&`, `or`/`||`, `not`
+- **Numbers**: decimal (`42`) or hex (`0x2a`)
+
+### Dynamic Offset/Size Example
+
+```yaml
+fields:
+  - name: filename_length
+    offset: 0x1A
+    size: 2
+    type: u16
+  - name: filename
+    offset: 0x1E
+    size: $filename_length
+    type: string
+```
+
+### Conditional Field Example
+
+```yaml
+fields:
+  - name: version
+    offset: 0
+    size: 1
+    type: u8
+  - name: extra
+    offset: 1
+    size: 1
+    type: u8
+    when: $version >= 2
+```
+
+### Computed Field Example
+
+```yaml
+fields:
+  - name: total_size
+    type: computed
+    value: $header_size + $payload_size
+```
+
+### Bitfield Example
+
+```yaml
+fields:
+  - name: flags
+    offset: 0
+    size: 1
+    type: u8
+    bitfields:
+      - name: is_compressed
+        bits: 0
+        type: bool
+      - name: level
+        bits: 2..5
+        type: u8
+```
+
+### Array Example
+
+```yaml
+fields:
+  - name: count
+    offset: 0
+    size: 1
+    type: u8
+  - name: entries
+    offset: 1
+    size: 1
+    type: u8
+    count: $count
+```
 
 ## Contributing
 

--- a/structs_library/compressed/zip_header.yaml
+++ b/structs_library/compressed/zip_header.yaml
@@ -126,17 +126,31 @@ fields:
     description: "Length of extra field following filename"
 
   # ============================================================================
-  # Variable-length fields (not at fixed offsets)
+  # Variable-length fields (dynamic offsets/sizes using field references)
   # ============================================================================
-  # 
-  # Filename (offset: 0x1E, size: filename_length)
-  #   ASCII or UTF-8 (if bit 11 of flags set)
+
+  - name: filename
+    offset: 0x1E
+    size: $filename_length
+    type: string
+    description: "Filename (variable length)"
+
+  - name: extra_field
+    offset: $filename_length + 0x1E
+    size: $extra_field_length
+    type: bytes
+    description: "Extra field data (variable length)"
+
+  - name: header_total_size
+    type: computed
+    value: 0x1E + $filename_length + $extra_field_length
+    description: "Total size of the local file header"
+
+  # ============================================================================
+  # Notes on remaining ZIP structure
+  # ============================================================================
   #
-  # Extra field (offset: 0x1E + filename_length, size: extra_field_length)
-  #   Contains extensible data blocks (timestamps, Unix permissions, etc.)
-  #   Each block: Header ID (2), Data Size (2), Data (variable)
-  #
-  # Compressed data (offset: 0x1E + filename_length + extra_field_length)
+  # Compressed data follows at offset 0x1E + filename_length + extra_field_length
   #   Size: compressed_size bytes
   #
   # Data descriptor (optional, if bit 3 of flags set)

--- a/structs_library/network/can_frame.yaml
+++ b/structs_library/network/can_frame.yaml
@@ -1,0 +1,57 @@
+# CAN 2.0A Standard Frame Header
+# Specification: ISO 11898-1
+# Purpose: Demonstrate bit-level parsing across byte boundaries
+#
+# This template parses the first 18 bits of a CAN 2.0A standard frame
+# stored in big-endian (MSB-first) bit order.
+#
+# Bit layout:
+#   bits 0..11  : Arbitration ID (11 bits)
+#   bit  11     : RTR (Remote Transmission Request)
+#   bit  12     : IDE (Identifier Extension, 0 for standard frame)
+#   bit  13     : r0 (reserved bit)
+#   bits 14..18 : DLC (Data Length Code, 0-8)
+#
+# Reference: https://www.iso.org/standard/63648.html
+
+name: CAN 2.0A Standard Frame Header
+endian: big
+fields:
+  - name: arbitration_id
+    offset: 0
+    bit_size: 11
+    type: u16
+    description: "11-bit arbitration identifier"
+
+  - name: rtr
+    offset: 1
+    bit_offset: 3
+    bit_size: 1
+    type: u8
+    description: "Remote Transmission Request (1 = remote frame)"
+
+  - name: ide
+    offset: 1
+    bit_offset: 4
+    bit_size: 1
+    type: u8
+    description: "Identifier Extension bit (0 = standard 11-bit ID)"
+
+  - name: r0
+    offset: 1
+    bit_offset: 5
+    bit_size: 1
+    type: u8
+    description: "Reserved bit"
+
+  - name: dlc
+    offset: 1
+    bit_offset: 6
+    bit_size: 4
+    type: u8
+    description: "Data Length Code (0-8 bytes)"
+
+  - name: data_byte_count
+    type: computed
+    value: $dlc
+    description: "Number of data bytes following the header"

--- a/structs_library/network/tcp_header.yaml
+++ b/structs_library/network/tcp_header.yaml
@@ -55,25 +55,27 @@ fields:
     # Only meaningful if ACK flag is set
     # Acknowledges all bytes up to (but not including) this number
     
-  - name: data_offset_and_reserved
+  # Byte 0x0C is bit-packed: Data Offset (4 bits) + Reserved (3 bits) + NS (1 bit)
+  # With big-endian (network) bit ordering, bit 0 is the MSB of the byte.
+  - name: data_offset
     offset: 0x0C
-    size: 1
+    bit_size: 4
     type: u8
-    description: "Data Offset (4 bits) + Reserved (3 bits) + NS flag (1 bit)"
-    display: hex
-    bitfields:
-      - name: ns
-        bits: 0
-        type: bool
-        description: "NS (ECN-nonce concealment protection)"
-      - name: reserved
-        bits: 1..3
-        type: u8
-        description: "Reserved (must be 0)"
-      - name: data_offset
-        bits: 4..7
-        type: u8
-        description: "Data Offset (header length in 32-bit words)"
+    description: "Data Offset (header length in 32-bit words)"
+
+  - name: reserved
+    offset: 0x0C
+    bit_offset: 4
+    bit_size: 3
+    type: u8
+    description: "Reserved (must be 0)"
+
+  - name: ns
+    offset: 0x0C
+    bit_offset: 7
+    bit_size: 1
+    type: u8
+    description: "NS (ECN-nonce concealment protection)"
 
   - name: flags
     offset: 0x0D
@@ -150,7 +152,7 @@ fields:
 
   - name: options_size
     type: computed
-    value: ($data_offset_and_reserved.data_offset - 5) * 4
+    value: ($data_offset - 5) * 4
     description: "TCP options size in bytes (0 if no options)"
 
   - name: options
@@ -158,7 +160,7 @@ fields:
     size: $options_size
     type: bytes
     description: "TCP options (variable length)"
-    when: $data_offset_and_reserved.data_offset > 5
+    when: $data_offset > 5
 
   # ============================================================================
   # Options Field - Variable length (0-40 bytes)

--- a/structs_library/network/tcp_header.yaml
+++ b/structs_library/network/tcp_header.yaml
@@ -61,25 +61,59 @@ fields:
     type: u8
     description: "Data Offset (4 bits) + Reserved (3 bits) + NS flag (1 bit)"
     display: hex
-    # Bits 7-4: Data Offset (header length in 32-bit words)
-    #           Minimum: 5 (20 bytes), Maximum: 15 (60 bytes)
-    # Bits 3-1: Reserved (must be 0)
-    # Bit 0: NS (ECN-nonce concealment protection)
-    
+    bitfields:
+      - name: ns
+        bits: 0
+        type: bool
+        description: "NS (ECN-nonce concealment protection)"
+      - name: reserved
+        bits: 1..3
+        type: u8
+        description: "Reserved (must be 0)"
+      - name: data_offset
+        bits: 4..7
+        type: u8
+        description: "Data Offset (header length in 32-bit words)"
+
   - name: flags
     offset: 0x0D
     size: 1
     type: u8
     description: "TCP control flags (8 bits)"
     display: hex
-    # Bit 7: CWR (Congestion Window Reduced)
-    # Bit 6: ECE (ECN-Echo)
-    # Bit 5: URG (Urgent pointer field significant)
-    # Bit 4: ACK (Acknowledgment field significant)
-    # Bit 3: PSH (Push function - deliver immediately)
-    # Bit 2: RST (Reset connection)
-    # Bit 1: SYN (Synchronize sequence numbers - connection setup)
-    # Bit 0: FIN (No more data from sender - connection teardown)
+    bitfields:
+      - name: fin
+        bits: 0
+        type: bool
+        description: "FIN - No more data from sender"
+      - name: syn
+        bits: 1
+        type: bool
+        description: "SYN - Synchronize sequence numbers"
+      - name: rst
+        bits: 2
+        type: bool
+        description: "RST - Reset connection"
+      - name: psh
+        bits: 3
+        type: bool
+        description: "PSH - Push function"
+      - name: ack
+        bits: 4
+        type: bool
+        description: "ACK - Acknowledgment field significant"
+      - name: urg
+        bits: 5
+        type: bool
+        description: "URG - Urgent pointer field significant"
+      - name: ece
+        bits: 6
+        type: bool
+        description: "ECE - ECN-Echo"
+      - name: cwr
+        bits: 7
+        type: bool
+        description: "CWR - Congestion Window Reduced"
     enum:
       2: "SYN - Connection initiation"
       18: "SYN-ACK - Connection acknowledgment"
@@ -111,7 +145,20 @@ fields:
     type: u16
     description: "Urgent pointer (offset to urgent data, if URG flag set)"
     display: hex
+    when: $flags.urg == 1
     # Rarely used, points to last byte of urgent data
+
+  - name: options_size
+    type: computed
+    value: ($data_offset_and_reserved.data_offset - 5) * 4
+    description: "TCP options size in bytes (0 if no options)"
+
+  - name: options
+    offset: 0x14
+    size: $options_size
+    type: bytes
+    description: "TCP options (variable length)"
+    when: $data_offset_and_reserved.data_offset > 5
 
   # ============================================================================
   # Options Field - Variable length (0-40 bytes)

--- a/tests/chain_integration.rs
+++ b/tests/chain_integration.rs
@@ -1,0 +1,158 @@
+//! Integration tests for the `chain` command.
+//!
+//! These tests invoke the compiled `binfiddle` binary via `std::process::Command`.
+
+use std::io::Write;
+use std::process::Command;
+
+/// Returns the path to the compiled `binfiddle` binary.
+fn binfiddle() -> std::path::PathBuf {
+    std::env::var_os("CARGO_BIN_EXE_binfiddle")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            // Fallback for running the test binary directly.
+            std::env::current_exe()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .join("binfiddle")
+        })
+}
+
+#[test]
+fn chain_two_byte_steps_produces_file() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), [0x00, 0x11, 0x22, 0x33]).unwrap();
+
+    let output = tempfile::NamedTempFile::new().unwrap();
+
+    let status = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("--output")
+        .arg(output.path())
+        .arg("chain")
+        .arg("--step")
+        .arg("edit replace 0..2 4142")
+        .arg("--step")
+        .arg("write 2 9999")
+        .status()
+        .expect("failed to run binfiddle chain");
+
+    assert!(status.success());
+    let result = std::fs::read(output.path()).unwrap();
+    assert_eq!(result, vec![0x41, 0x42, 0x99, 0x99]);
+}
+
+#[test]
+fn chain_final_text_step_prints_to_stdout() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), [0x41, 0x42, 0x43]).unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("chain")
+        .arg("--step")
+        .arg("write 0 44")
+        .arg("--step")
+        .arg("read 0..3")
+        .output()
+        .expect("failed to run binfiddle chain");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("44"),
+        "Expected stdout to contain the edited byte 44, got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn chain_intermediate_text_step_fails() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), [0xDE, 0xAD, 0xBE, 0xEF]).unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("chain")
+        .arg("--step")
+        .arg("read 0..2")
+        .arg("--step")
+        .arg("write 0 00")
+        .output()
+        .expect("failed to run binfiddle chain");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("produced no byte output"),
+        "Expected intermediate text step to fail, got stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn chain_from_stdin_to_output_file() {
+    let output_file = tempfile::NamedTempFile::new().unwrap();
+
+    let mut child = Command::new(binfiddle())
+        .arg("--input")
+        .arg("-")
+        .arg("--output")
+        .arg(output_file.path())
+        .arg("chain")
+        .arg("--step")
+        .arg("write 0 42")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn binfiddle chain");
+
+    let mut stdin = child.stdin.take().expect("failed to open stdin");
+    std::thread::spawn(move || {
+        stdin.write_all(&[0x00, 0x00]).unwrap();
+    });
+
+    let output = child
+        .wait_with_output()
+        .expect("failed to wait on binfiddle chain");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result = std::fs::read(output_file.path()).unwrap();
+    assert_eq!(result, vec![0x42, 0x00]);
+}
+
+#[test]
+fn chain_empty_steps_rejected() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), [0x00]).unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("chain")
+        .output()
+        .expect("failed to run binfiddle chain");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("required arguments were not provided") && stderr.contains("--step"),
+        "Expected rejection of empty chain, got stderr: {}",
+        stderr
+    );
+}

--- a/tests/hash_integration.rs
+++ b/tests/hash_integration.rs
@@ -141,3 +141,145 @@ fn hash_block_based_crc32() {
     assert!(lines[1].starts_with("0x00000003:"));
     assert!(lines[2].starts_with("0x00000006:"));
 }
+
+#[test]
+fn hash_sha1_of_known_string() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), b"hello").unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("hash")
+        .arg("sha1")
+        .output()
+        .expect("failed to run binfiddle hash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert_eq!(stdout, "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d");
+}
+
+#[test]
+fn hash_xxhash64_of_known_string() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), b"hello").unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("hash")
+        .arg("xxhash64")
+        .output()
+        .expect("failed to run binfiddle hash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert_eq!(stdout, "26c7827d889f6da3");
+}
+
+#[test]
+fn hash_base64_output() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), b"hello").unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("hash")
+        .arg("md5")
+        .arg("--output-format")
+        .arg("base64")
+        .output()
+        .expect("failed to run binfiddle hash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert_eq!(stdout, "XUFAKrxLKna5cZ2REBfFkg==");
+}
+
+#[test]
+fn hash_stream_matches_non_stream() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), b"hello world this is a stream test").unwrap();
+
+    let non_stream = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("hash")
+        .arg("sha256")
+        .output()
+        .expect("failed to run binfiddle hash");
+
+    let stream = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("hash")
+        .arg("sha256")
+        .arg("--stream")
+        .arg("--read-block-size")
+        .arg("8")
+        .output()
+        .expect("failed to run binfiddle hash stream");
+
+    assert!(
+        non_stream.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&non_stream.stderr)
+    );
+    assert!(
+        stream.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&stream.stderr)
+    );
+
+    assert_eq!(
+        String::from_utf8_lossy(&non_stream.stdout).trim(),
+        String::from_utf8_lossy(&stream.stdout).trim()
+    );
+}
+
+#[test]
+fn hash_stream_block_hashing() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), b"123456789").unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("hash")
+        .arg("crc32")
+        .arg("--block-size")
+        .arg("3")
+        .arg("--stream")
+        .arg("--read-block-size")
+        .arg("5")
+        .output()
+        .expect("failed to run binfiddle hash stream");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), 3, "Expected 3 block hashes, got: {}", stdout);
+    assert!(lines[0].starts_with("0x00000000:"));
+}

--- a/tests/hash_integration.rs
+++ b/tests/hash_integration.rs
@@ -283,3 +283,84 @@ fn hash_stream_block_hashing() {
     assert_eq!(lines.len(), 3, "Expected 3 block hashes, got: {}", stdout);
     assert!(lines[0].starts_with("0x00000000:"));
 }
+
+#[test]
+fn hash_check_from_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_a = dir.path().join("a.bin");
+    let file_b = dir.path().join("b.bin");
+    std::fs::write(&file_a, b"hello").unwrap();
+    std::fs::write(&file_b, b"world").unwrap();
+
+    // Compute known digest for a.bin.
+    let good = Command::new(binfiddle())
+        .arg("--input")
+        .arg(&file_a)
+        .arg("hash")
+        .arg("sha256")
+        .output()
+        .unwrap()
+        .stdout;
+    let good = String::from_utf8_lossy(&good).trim().to_string();
+
+    let checksum_file = dir.path().join("checksums.sha256");
+    std::fs::write(
+        &checksum_file,
+        format!("{}  a.bin\n{}  b.bin\n", good, "0".repeat(64)),
+    )
+    .unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("hash")
+        .arg("sha256")
+        .arg("--check")
+        .arg(&checksum_file)
+        .output()
+        .expect("failed to run binfiddle hash --check");
+
+    assert!(
+        !output.status.success(),
+        "Expected checksum verification to fail"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("a.bin: OK"), "Got: {}", stdout);
+    assert!(stdout.contains("b.bin: FAILED"), "Got: {}", stdout);
+    assert!(stdout.contains("1 passed, 1 failed"), "Got: {}", stdout);
+}
+
+#[test]
+fn hash_check_all_pass() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("data.bin");
+    std::fs::write(&file, b"check me").unwrap();
+
+    let digest = Command::new(binfiddle())
+        .arg("--input")
+        .arg(&file)
+        .arg("hash")
+        .arg("md5")
+        .output()
+        .unwrap()
+        .stdout;
+    let digest = String::from_utf8_lossy(&digest).trim().to_string();
+
+    let checksum_file = dir.path().join("checksums.md5");
+    std::fs::write(&checksum_file, format!("{}  data.bin\n", digest)).unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("hash")
+        .arg("md5")
+        .arg("--check")
+        .arg(&checksum_file)
+        .output()
+        .expect("failed to run binfiddle hash --check");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("data.bin: OK"), "Got: {}", stdout);
+    assert!(stdout.contains("1 passed, 0 failed"), "Got: {}", stdout);
+}

--- a/tests/hash_integration.rs
+++ b/tests/hash_integration.rs
@@ -1,0 +1,143 @@
+//! Integration tests for the `hash` command.
+
+use std::process::Command;
+
+fn binfiddle() -> std::path::PathBuf {
+    std::env::var_os("CARGO_BIN_EXE_binfiddle")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            std::env::current_exe()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .join("binfiddle")
+        })
+}
+
+#[test]
+fn hash_sha256_of_known_string() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), b"hello").unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("hash")
+        .arg("sha256")
+        .output()
+        .expect("failed to run binfiddle hash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert_eq!(
+        stdout,
+        "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    );
+}
+
+#[test]
+fn hash_md5_of_empty_file() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("hash")
+        .arg("md5")
+        .output()
+        .expect("failed to run binfiddle hash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert_eq!(stdout, "d41d8cd98f00b204e9800998ecf8427e");
+}
+
+#[test]
+fn hash_blake3_of_known_string() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), b"hello").unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("hash")
+        .arg("blake3")
+        .output()
+        .expect("failed to run binfiddle hash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert_eq!(
+        stdout,
+        "ea8f163db38682925e4491c5e58d4bb3506ef8c14eb78a86e908c5624a67200f"
+    );
+}
+
+#[test]
+fn hash_crc32_of_known_string() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), b"123456789").unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("hash")
+        .arg("crc32")
+        .output()
+        .expect("failed to run binfiddle hash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert_eq!(stdout, "cbf43926");
+}
+
+#[test]
+fn hash_block_based_crc32() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), b"123456789").unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("hash")
+        .arg("crc32")
+        .arg("--block-size")
+        .arg("3")
+        .output()
+        .expect("failed to run binfiddle hash");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), 3, "Expected 3 block hashes, got: {}", stdout);
+    assert!(lines[0].starts_with("0x00000000:"));
+    assert!(lines[1].starts_with("0x00000003:"));
+    assert!(lines[2].starts_with("0x00000006:"));
+}

--- a/tests/process_memory_integration.rs
+++ b/tests/process_memory_integration.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the experimental `--process-self` feature.
+//! Integration tests for process memory access (`--process-self` and `--pid`).
 
 use std::process::Command;
 
@@ -26,8 +26,8 @@ fn process_self_requires_address_and_size() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("--address") && stderr.contains("--size"),
-        "Expected --address and --size to be required, got: {}",
+        stderr.contains("--address") || stderr.contains("--size"),
+        "Expected missing --address/--size error, got: {}",
         stderr
     );
 }
@@ -50,8 +50,33 @@ fn process_self_invalid_address_fails_gracefully() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("Process memory error") || stderr.contains("Failed to read process memory"),
+        stderr.contains("Process memory error") || stderr.contains("Failed to read process"),
         "Expected process memory error, got: {}",
         stderr
+    );
+}
+
+#[test]
+fn process_self_lists_regions() {
+    let output = Command::new(binfiddle())
+        .args(["--process-self", "--list-regions"])
+        .output()
+        .expect("failed to run binfiddle");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Memory regions"),
+        "Expected region listing header, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("r-xp") || stdout.contains("rw-p") || stdout.contains("r--p"),
+        "Expected memory permissions in listing, got: {}",
+        stdout
     );
 }

--- a/tests/process_memory_integration.rs
+++ b/tests/process_memory_integration.rs
@@ -247,3 +247,152 @@ fn cross_process_force_writable_modifies_readonly_page() {
     let status = child.wait().expect("helper did not exit");
     assert!(status.success(), "helper exited with non-zero status");
 }
+
+#[test]
+fn zero_fill_inaccessible_fills_unmapped_self_address() {
+    // Reading address 0 without --zero-fill-inaccessible fails because it is
+    // not mapped; with the flag it is replaced by a zero byte.
+    let output = Command::new(binfiddle())
+        .args([
+            "--process-self",
+            "--address",
+            "0",
+            "--size",
+            "1",
+            "--zero-fill-inaccessible",
+            "--format",
+            "hex",
+            "read",
+            "0..1",
+        ])
+        .output()
+        .expect("failed to run binfiddle");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("00"),
+        "Expected zero-filled byte, got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn zero_fill_inaccessible_requires_process_source() {
+    let output = Command::new(binfiddle())
+        .args([
+            "-i",
+            "/dev/null",
+            "--zero-fill-inaccessible",
+            "read",
+            "0..1",
+        ])
+        .output()
+        .expect("failed to run binfiddle");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--process-self") || stderr.contains("--pid"),
+        "Expected process-source requirement error, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn skip_inaccessible_requires_read_command() {
+    let output = Command::new(binfiddle())
+        .args([
+            "--process-self",
+            "--address",
+            "0x1000",
+            "--size",
+            "1",
+            "--skip-inaccessible",
+            "search",
+            "00",
+        ])
+        .output()
+        .expect("failed to run binfiddle");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("read command") || stderr.contains("only supported with the read command"),
+        "Expected read-command restriction error, got: {}",
+        stderr
+    );
+}
+
+#[test]
+#[ignore = "requires ptrace access (run with --ignored --test-threads=1)"]
+fn cross_process_search_finds_readonly_static() {
+    if !ptrace_scope_permits_parent_child() {
+        return;
+    }
+
+    let (helper_path, _helper_dir) = compile_force_write_helper();
+    let mut child = Command::new(&helper_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn force-write helper");
+
+    let stdout = child.stdout.take().expect("helper stdout missing");
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .expect("failed to read helper announcement");
+
+    let mut parts = line.split_whitespace();
+    let pid: u32 = parts
+        .next()
+        .expect("missing pid")
+        .parse()
+        .expect("invalid pid");
+    let address = parts.next().expect("missing address");
+
+    let search_output = Command::new(binfiddle())
+        .args([
+            "--pid",
+            &pid.to_string(),
+            "--address",
+            address,
+            "--size",
+            "8",
+            "search",
+            "CHANGEME",
+            "--input-format",
+            "ascii",
+            "--all",
+            "--offsets-only",
+        ])
+        .output()
+        .expect("failed to run binfiddle search");
+    if !search_output.status.success() {
+        let stderr = String::from_utf8_lossy(&search_output.stderr);
+        if stderr.contains("Operation not permitted") || stderr.contains("Permission denied") {
+            let _ = child.kill();
+            let _ = child.wait();
+            return;
+        }
+        panic!("search failed: {}", stderr);
+    }
+
+    let stdout = String::from_utf8_lossy(&search_output.stdout);
+    assert!(
+        stdout.contains("0x"),
+        "Expected search to report an offset, got: {}",
+        stdout
+    );
+
+    let mut stdin = child.stdin.take().expect("helper stdin missing");
+    stdin.write_all(b"\n").expect("failed to write to helper");
+    let status = child.wait().expect("helper did not exit");
+    assert!(status.success(), "helper exited with non-zero status");
+}

--- a/tests/process_memory_integration.rs
+++ b/tests/process_memory_integration.rs
@@ -1,6 +1,7 @@
 //! Integration tests for process memory access (`--process-self` and `--pid`).
 
-use std::process::Command;
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
 
 fn binfiddle() -> std::path::PathBuf {
     std::env::var_os("CARGO_BIN_EXE_binfiddle")
@@ -50,7 +51,9 @@ fn process_self_invalid_address_fails_gracefully() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("Process memory error") || stderr.contains("Failed to read process"),
+        stderr.contains("ProcessMemoryError")
+            || stderr.contains("Process memory error")
+            || stderr.contains("Failed to read process memory"),
         "Expected process memory error, got: {}",
         stderr
     );
@@ -79,4 +82,168 @@ fn process_self_lists_regions() {
         "Expected memory permissions in listing, got: {}",
         stdout
     );
+}
+
+#[test]
+fn force_writable_requires_allow_write() {
+    let output = Command::new(binfiddle())
+        .args([
+            "--process-self",
+            "--address",
+            "0x1000",
+            "--size",
+            "1",
+            "--force-writable",
+            "write",
+            "0",
+            "FF",
+        ])
+        .output()
+        .expect("failed to run binfiddle");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--allow-write") || stderr.contains("allow_write"),
+        "Expected --force-writable to require --allow-write, got: {}",
+        stderr
+    );
+}
+
+const FORCE_WRITE_HELPER_SRC: &str = r#"
+use std::io::{self, Read, Write};
+
+static TARGET: [u8; 8] = *b"CHANGEME";
+
+fn main() {
+    println!("{} {}", std::process::id(), &TARGET as *const _ as usize);
+    io::stdout().flush().unwrap();
+    // Wait for the parent to signal us to exit.
+    let mut buf = [0u8; 1];
+    let _ = io::stdin().read_exact(&mut buf);
+}
+"#;
+
+fn compile_force_write_helper() -> (std::path::PathBuf, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("failed to create temp dir");
+    let src = dir.path().join("helper.rs");
+    let bin = dir.path().join("helper");
+    std::fs::write(&src, FORCE_WRITE_HELPER_SRC).expect("failed to write helper source");
+
+    let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    let status = Command::new(rustc)
+        .args(["--edition", "2021", "-C", "opt-level=0", "-o"])
+        .arg(&bin)
+        .arg(&src)
+        .status()
+        .expect("failed to run rustc");
+    assert!(
+        status.success(),
+        "rustc failed to compile force-write helper"
+    );
+
+    (bin, dir)
+}
+
+fn ptrace_scope_permits_parent_child() -> bool {
+    match std::fs::read_to_string("/proc/sys/kernel/yama/ptrace_scope") {
+        Ok(content) => content
+            .trim()
+            .parse::<i32>()
+            .map(|value| value <= 1)
+            .unwrap_or(true),
+        Err(_) => true,
+    }
+}
+
+#[test]
+#[ignore = "requires ptrace access (run with --ignored --test-threads=1)"]
+fn cross_process_force_writable_modifies_readonly_page() {
+    if !ptrace_scope_permits_parent_child() {
+        return;
+    }
+
+    let (helper_path, _helper_dir) = compile_force_write_helper();
+    let mut child = Command::new(&helper_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn force-write helper");
+
+    let stdout = child.stdout.take().expect("helper stdout missing");
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .expect("failed to read helper announcement");
+
+    let mut parts = line.split_whitespace();
+    let pid: u32 = parts
+        .next()
+        .expect("missing pid")
+        .parse()
+        .expect("invalid pid");
+    let address = parts.next().expect("missing address");
+
+    // Temporarily make the helper's read-only static writable and overwrite it.
+    let write_output = Command::new(binfiddle())
+        .args([
+            "--pid",
+            &pid.to_string(),
+            "--address",
+            address,
+            "--size",
+            "8",
+            "--allow-write",
+            "--force-writable",
+            "write",
+            "0",
+            "464f524345575254",
+        ])
+        .output()
+        .expect("failed to run binfiddle write");
+    if !write_output.status.success() {
+        let stderr = String::from_utf8_lossy(&write_output.stderr);
+        if stderr.contains("Operation not permitted") || stderr.contains("Permission denied") {
+            // The environment (e.g. seccomp, capabilities) blocks cross-process
+            // vm access even though Yama allows it. Skip the rest of the test.
+            let _ = child.kill();
+            let _ = child.wait();
+            return;
+        }
+        panic!("write failed: {}", stderr);
+    }
+
+    // Read back the modified bytes as raw output.
+    let read_output = Command::new(binfiddle())
+        .args([
+            "--pid",
+            &pid.to_string(),
+            "--address",
+            address,
+            "--size",
+            "8",
+            "read",
+            "..",
+            "--format",
+            "raw",
+        ])
+        .output()
+        .expect("failed to run binfiddle read");
+    if !read_output.status.success() {
+        let stderr = String::from_utf8_lossy(&read_output.stderr);
+        if stderr.contains("Operation not permitted") || stderr.contains("Permission denied") {
+            let _ = child.kill();
+            let _ = child.wait();
+            return;
+        }
+        panic!("read failed: {}", stderr);
+    }
+    assert_eq!(read_output.stdout, b"FORCEWRT");
+
+    // Signal the helper to exit.
+    let mut stdin = child.stdin.take().expect("helper stdin missing");
+    stdin.write_all(b"\n").expect("failed to write to helper");
+    let status = child.wait().expect("helper did not exit");
+    assert!(status.success(), "helper exited with non-zero status");
 }

--- a/tests/process_self_integration.rs
+++ b/tests/process_self_integration.rs
@@ -1,0 +1,57 @@
+//! Integration tests for the experimental `--process-self` feature.
+
+use std::process::Command;
+
+fn binfiddle() -> std::path::PathBuf {
+    std::env::var_os("CARGO_BIN_EXE_binfiddle")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            std::env::current_exe()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .join("binfiddle")
+        })
+}
+
+#[test]
+fn process_self_requires_address_and_size() {
+    let output = Command::new(binfiddle())
+        .args(["--process-self", "read", "0..1"])
+        .output()
+        .expect("failed to run binfiddle");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--address") && stderr.contains("--size"),
+        "Expected --address and --size to be required, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn process_self_invalid_address_fails_gracefully() {
+    let output = Command::new(binfiddle())
+        .args([
+            "--process-self",
+            "--address",
+            "0x1",
+            "--size",
+            "1",
+            "read",
+            "0..1",
+        ])
+        .output()
+        .expect("failed to run binfiddle");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Process memory error") || stderr.contains("Failed to read process memory"),
+        "Expected process memory error, got: {}",
+        stderr
+    );
+}

--- a/tests/streaming_analyze_integration.rs
+++ b/tests/streaming_analyze_integration.rs
@@ -1,0 +1,164 @@
+//! Integration tests for streaming `analyze --block-size`.
+
+use std::io::Write;
+use std::process::Command;
+
+fn binfiddle() -> std::path::PathBuf {
+    std::env::var_os("CARGO_BIN_EXE_binfiddle")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            std::env::current_exe()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .join("binfiddle")
+        })
+}
+
+#[test]
+fn streaming_analyze_entropy_per_block() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    // Two blocks: one uniform, one mixed.
+    let mut data = vec![0x00u8; 4];
+    data.extend(vec![0x00, 0x11, 0x22, 0x33]);
+    std::fs::write(input.path(), &data).unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("analyze")
+        .arg("entropy")
+        .arg("--block-size")
+        .arg("4")
+        .output()
+        .expect("failed to run binfiddle analyze");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Blocks: 2"),
+        "Expected 2 blocks, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("0x00000000"),
+        "Expected first block offset, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("0x00000004"),
+        "Expected second block offset, got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn streaming_analyze_histogram_accumulates() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), [0xAA, 0xAA, 0xBB, 0xCC]).unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("analyze")
+        .arg("histogram")
+        .arg("--block-size")
+        .arg("2")
+        .output()
+        .expect("failed to run binfiddle analyze");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Total bytes: 4"),
+        "Expected total bytes 4, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("0xaa"),
+        "Expected 0xaa in histogram, got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn streaming_analyze_from_stdin() {
+    let mut data = vec![0x00u8; 8];
+    data.extend(vec![0xFFu8; 8]);
+
+    let mut child = Command::new(binfiddle())
+        .arg("--input")
+        .arg("-")
+        .arg("analyze")
+        .arg("entropy")
+        .arg("--block-size")
+        .arg("8")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn binfiddle analyze");
+
+    let mut stdin = child.stdin.take().expect("failed to open stdin");
+    std::thread::spawn(move || {
+        stdin.write_all(&data).unwrap();
+    });
+
+    let output = child
+        .wait_with_output()
+        .expect("failed to wait on binfiddle analyze");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Blocks: 2"),
+        "Expected 2 blocks from stdin, got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn streaming_analyze_rejects_range() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), [0x00; 8]).unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("analyze")
+        .arg("entropy")
+        .arg("--block-size")
+        .arg("4")
+        .arg("--range")
+        .arg("0..4")
+        .output()
+        .expect("failed to run binfiddle analyze");
+
+    assert!(
+        !output.status.success(),
+        "Expected --range with streaming analyze to fail"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not supported"),
+        "Expected unsupported error, got: {}",
+        stderr
+    );
+}

--- a/tests/streaming_search_integration.rs
+++ b/tests/streaming_search_integration.rs
@@ -1,0 +1,188 @@
+//! Integration tests for the streaming `search --block-size` path.
+
+use std::io::Write;
+use std::process::Command;
+
+fn binfiddle() -> std::path::PathBuf {
+    std::env::var_os("CARGO_BIN_EXE_binfiddle")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            std::env::current_exe()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .join("binfiddle")
+        })
+}
+
+#[test]
+fn streaming_search_finds_exact_match() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), [0xDE, 0xAD, 0xBE, 0xEF, 0x00]).unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("search")
+        .arg("DEADBEEF")
+        .arg("--all")
+        .arg("--block-size")
+        .arg("2")
+        .output()
+        .expect("failed to run binfiddle search");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("0x00000000"),
+        "Expected match at offset 0, got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn streaming_search_finds_boundary_match() {
+    // Pattern straddles the boundary between 4-byte blocks.
+    let mut data = vec![0x00u8; 10];
+    data[3..7].copy_from_slice(&[0xCA, 0xFE, 0xBA, 0xBE]);
+
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), &data).unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("search")
+        .arg("CAFEBABE")
+        .arg("--all")
+        .arg("--offsets-only")
+        .arg("--block-size")
+        .arg("4")
+        .output()
+        .expect("failed to run binfiddle search");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout.trim(),
+        "0x00000003",
+        "Expected boundary match at offset 3, got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn streaming_search_finds_ascii_pattern() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), b"hello world").unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("search")
+        .arg("world")
+        .arg("--input-format")
+        .arg("ascii")
+        .arg("--all")
+        .arg("--block-size")
+        .arg("3")
+        .output()
+        .expect("failed to run binfiddle search");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("0x00000006"),
+        "Expected match at offset 6, got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn streaming_search_from_stdin() {
+    let mut data = vec![0x00u8; 10];
+    data[7..9].copy_from_slice(&[0xAA, 0xBB]);
+
+    let mut child = Command::new(binfiddle())
+        .arg("--input")
+        .arg("-")
+        .arg("search")
+        .arg("AABB")
+        .arg("--all")
+        .arg("--block-size")
+        .arg("3")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn binfiddle search");
+
+    let mut stdin = child.stdin.take().expect("failed to open stdin");
+    std::thread::spawn(move || {
+        stdin.write_all(&data).unwrap();
+    });
+
+    let output = child
+        .wait_with_output()
+        .expect("failed to wait on binfiddle search");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("0x00000007"),
+        "Expected match at offset 7, got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn streaming_search_rejects_regex() {
+    let input = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(input.path(), b"hello").unwrap();
+
+    let output = Command::new(binfiddle())
+        .arg("--input")
+        .arg(input.path())
+        .arg("search")
+        .arg(".*")
+        .arg("--input-format")
+        .arg("regex")
+        .arg("--all")
+        .arg("--block-size")
+        .arg("4")
+        .output()
+        .expect("failed to run binfiddle search");
+
+    assert!(
+        !output.status.success(),
+        "Expected regex + --block-size to fail"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not supported"),
+        "Expected unsupported error, got: {}",
+        stderr
+    );
+}


### PR DESCRIPTION
## Summary

`binfiddle` has grown from a read/search/analyze/diff utility into a tool that can also inspect and edit running process memory, chain commands, stream multi-gigabyte inputs without loading them whole, hash and verify files, and report progress on long operations. Every new feature is gated by the existing quality suite (`cargo fmt`, `clippy -D warnings`, `cargo test --release`, and cross-compilation to `aarch64-unknown-linux-gnu`).

## Highlights

- **Large-file support**: file input is now memory-mapped; commands like `search`, `analyze`, `hash`, and `diff` can operate on files larger than RAM. Streaming/block variants keep only a small window resident.
- **Process memory inspection and editing** (Linux): read `/proc/self/mem` or `/proc/<pid>/mem`, list maps, write across processes, and force-writable patches on read-only regions (x86_64 and aarch64).
- **Hash command**: MD5, SHA-1, SHA-256, BLAKE3, CRC32, and xxhash64 with hex/base64 output, per-block hashing, incremental streaming, and md5sum/sha256sum-compatible `--check` verification.
- **Streaming search/analyze**: `--block-size` walks huge files in chunks without paging the whole input.
- **In-place file patching**: `write --in-file` uses a writable memory map so large files can be patched without a full memory copy.
- **Command chaining**: `chain` lets users compose read/write/edit/search operations in a single invocation.
- **Progress bars**: opt-in `--progress` gives throughput/ETA feedback for `hash`, `search --all`, `analyze`, and `convert`; suppressed automatically in pipes, scripts, and command chaining.

## Detailed changelog

### v0.12.0 — Dynamic struct template system evolution

- Evolved the `struct` command so templates can be defined and reused more flexibly.
- Laid groundwork for later bit-level precision improvements.

### v0.13.0 — Bit-level precision for templates

- Added bit-level field extraction for struct templates (fields that start or span partial bytes, endianness-aware bit reads, sign extension).

### v0.14.0 — Command chaining & pipelines

- New `chain` subcommand that runs multiple `binfiddle` steps in sequence, passing byte output from one step to the next.
- Supports both byte-producing and text-producing intermediate steps.

### v0.15.0 — Read-only `/proc/self` memory access

- Added `--process-self` / `--address` / `--size` flags to read the current process's memory through `/proc/self/mem`.

### v0.16.0 — Cross-process reads, maps, and current-process writes

- Extended process-memory support to other PIDs (`--pid`).
- Added memory-region listing and cross-process read paths.
- Enabled current-process writes.

### v0.17.0 — Cross-process writes via `process_vm_writev`

- Implemented remote process memory writes using `process_vm_writev`.

### v0.18.0 — Force-writable patches for read-only regions

- Added `--force-writable` / `--allow-write` to temporarily `mprotect` read-only mappings writable for in-process edits, then restore the original protection.

### v0.19.0 — Process memory hardening

- Region-boundary validation, RAII protection-restoration guards, always-detach ptrace guard, `ptrace_scope` diagnostics, and expanded tests/docs.

### v0.20.0 — AArch64 cross-platform force-writable support

- Extended `--force-writable` cross-process writes to Linux aarch64 while preserving the x86_64 path.
- Added `cargo check --target aarch64-unknown-linux-gnu` to the quality gate.

### v0.21.0 — Sparse process-memory reads and process-memory search

- Added `FillMode` (`Error`, `ZeroFill`, `Skip`) for sparse reads over `/proc/<pid>/maps`.
- Added `--zero-fill-inaccessible` / `--skip-inaccessible` flags.
- Enabled `search` against `--process-self` / `--pid` sources.

### v0.22.0 — Memory-map file input for large files

- `BinarySource::File` now uses `memmap2` instead of `std::fs::read`.
- Mutation methods lazily copy the mapped region into an owned `Vec` only when needed.
- Added `BinaryData::as_bytes()` to avoid full-file copies in `search`, `analyze`, `convert`, and output paths.

### v0.23.0 — Hash command, streaming search, writable `MmapMut`, and tests

- New `hash` subcommand supporting MD5, SHA-256, BLAKE3, CRC32 with optional per-block output.
- Streaming/block search via `search --block-size` for files larger than RAM.
- Writable `MmapMut` backing so `write --in-file` patches files directly on disk.
- Added integration tests for the `chain` command and process-memory features.

### v0.24.0 — Streaming analyze for huge files

- `analyze --block-size` now streams the input instead of memory-mapping it.
- Block-based entropy and Index of Coincidence, plus global histogram accumulation, work on files larger than RAM.

### v0.25.0 — Extend hash with SHA-1, xxhash64, base64, and streaming

- Added SHA-1 and xxhash64 algorithms.
- Added base64 output encoding.
- Added `--stream` / `--read-block-size` for incremental hashing of huge files.

### v0.26.0 — `--check` mode for hash

- md5sum/sha256sum-compatible checksum verification.
- Reads digest/filename lines, hashes each file incrementally, reports `OK`/`FAILED`, and exits non-zero on mismatch.

### v0.27.0 — Opt-in progress bars

- Added `indicatif`-based progress bars for `hash`, `search --all`, `analyze`, and `convert`.
- Controlled by `--progress`; automatically suppressed when stderr is not a TTY, when `--silent` is used, or inside command chaining.

## Testing

All changes are covered by the existing test matrix:

```bash
cargo fmt --check
cargo clippy --all-targets -- -D warnings
cargo test --release
cargo check --target aarch64-unknown-linux-gnu
```

As of v0.27.0 the suite reports:

- 293 unit tests
- 5 chain integration tests
- 12 hash integration tests
- 5 streaming-search integration tests
- 4 streaming-analyze integration tests
- 7 process-memory integration tests (2 ptrace tests ignored by default)

## Backwards compatibility / migration notes

- Progress bars are now **opt-in** (`--progress`). Scripts and pipes that previously relied on the automatic TTY behavior from the intermediate v0.27.0 commit should pass `--progress` explicitly if they want bars.
- `--block-size` for `analyze` now accepts human suffixes (`K`, `M`, `G`) in addition to plain bytes.
- `--block-size` for `search` accepts human suffixes.
- New global flags: `--progress`, plus command-specific flags `--stream`, `--read-block-size`, `--check`, `--zero-fill-inaccessible`, `--skip-inaccessible`, `--allow-write`, `--force-writable`, `--process-self`, `--pid`.
- Process-memory features remain Linux-only and gated at compile time; other platforms compile without them.